### PR TITLE
ASC-572 Remove check for placement user

### DIFF
--- a/molecule/default/tests/test_env_scan.py
+++ b/molecule/default/tests/test_env_scan.py
@@ -46,7 +46,6 @@ def test_users(host):
     assert "keystone" in user_names
     assert "neutron" in user_names
     assert "nova" in user_names
-    assert "placement" in user_names
     assert "swift" in user_names
 
 


### PR DESCRIPTION
The `placement` user is not present on a `newton` deployment. This
commit removes the check for this user.