### PR TITLE
ASC-241 - Test instance per net per hypervisor

### DIFF
--- a/molecule/default/tests/test_instance_per_network_per_hypervisor.py
+++ b/molecule/default/tests/test_instance_per_network_per_hypervisor.py
@@ -1,0 +1,130 @@
+import os
+import testinfra.utils.ansible_runner
+import pytest
+import random
+import json
+import time
+
+"""ASC-241: Per network, spin up an instance on each hypervisor, perform
+external ping, and tear-down """
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('os-infra_hosts')[:1]
+
+os_pre = ("lxc-attach -n $(lxc-ls -1 | grep utility | head -n 1) "
+          "-- bash -c '. /root/openrc ; openstack ")
+os_post = "'"
+
+
+@pytest.fixture
+def create_server_on(target_host, image_id, flavor, network_id, compute_zone, server_name):
+    cmd = "{} server create \
+           -f json \
+           --image {} \
+           --flavor {} \
+           --nic net-id={} \
+           --availability-zone {} \
+           {} {}".format(os_pre, image_id, flavor,
+                         network_id, compute_zone, server_name, os_post)
+    res = target_host.run(cmd)
+    server = json.loads(res.stdout)
+    yield server
+    target_host.run("{} server delete {} {}".format(os_pre, server['id'],
+                                                    os_post))
+
+
+@pytest.fixture
+def create_flavor_on(target_host, flavor):
+    flavor_cmd = "{} flavor create --ram 512 --disk 10 \
+                  --vcpus 1 {} {}".format(os_pre, flavor, os_post)
+    target_host.run_expect([0], flavor_cmd)
+    yield
+    target_host.run("{} flavor delete {} {}".format(os_pre, flavor,
+                                                    os_post))
+
+
+@pytest.mark.test_id('c3002bde-59f1-11e8-be3b-6c96cfdb252f')
+@pytest.mark.jira('ASC-241')
+def test_hypervisor_vms(host):
+    """ASC-241: Per network, spin up an instance on each hypervisor, perform
+    external ping, and tear-down """
+
+    server_list = []
+    # get image id
+    cmd = "{} image list -f json {}".format(os_pre, os_post)
+    res = host.run(cmd)
+    images = json.loads(res.stdout)
+    filtered_images = list(filter(lambda d: 'buntu' in d['Name'], images))
+    assert len(filtered_images) > 0
+    image = filtered_images[-1]
+
+    cmd = "lxc-ls -1 | egrep 'neutron(_|-)agents' | tail -1"
+    res = host.run(cmd)
+    container = res.stdout.strip()
+    lxc_pre = "lxc-attach -n {} ".format(container)
+
+    r = random.randint(1111, 9999)
+    flavor = "rpctest-{}-flavor".format(r)
+    create_flavor_on(host, flavor)
+
+    net_cmd = "{} network list -f json {}".format(os_pre, os_post)
+    net_res = host.run(net_cmd)
+    networks = json.loads(net_res.stdout)
+    for network in networks:
+        cmd = "{} network show {} -f json {}".format(os_pre, network['ID'],
+                                                     os_post)
+        res = host.run(cmd)
+        network_detail = json.loads(res.stdout)
+        if network_detail['router:external'] == 'External':
+            continue
+        # spin up instance per hypervisor
+        cmd = "{} compute service list -f json {}".format(os_pre, os_post)
+        res = host.run(cmd)
+        computes = json.loads(res.stdout)
+        for compute in computes:
+            if compute['Binary'] == 'nova-compute':
+                instance_name = "rpctest-{}-{}-{}".format(r, compute['Host'],
+                                                          network_detail['name'])
+                server = create_server_on(host, image['ID'], flavor,
+                                          network['ID'], compute['Zone'],
+                                          instance_name)
+                server_list.append(server)
+
+    # sleep to allow servers to boot
+    time.sleep(60)
+
+    for server in server_list:
+        cmd = "{} server show {} -f json {}".format(os_pre, server['id'],
+                                                    os_post)
+        res = host.run(cmd)
+        s = json.loads(res.stdout)
+        assert s['status'] == 'ACTIVE'
+
+        # test ssh
+        network_name, ip = s['addresses'].split('=')
+        # get network detail (again)
+        # This will include network id and subnets.
+        cmd = "{} network show {} -f json {}".format(os_pre, network_name,
+                                                     os_post)
+        res = host.run(cmd)
+        network = json.loads(res.stdout)
+
+        # confirm SSH port access
+        cmd = "{} -- bash \
+               -c 'ip netns exec qdhcp-{} nc -w1 {} 22'".format(lxc_pre,
+                                                                network['id'],
+                                                                ip)
+        res = host.run(cmd)
+        assert 'SSH' in res.stdout
+
+        # get gateway ip via subnet detail
+        cmd = "{} subnet show {} -f json {}".format(os_pre,
+                                                    network['subnets'], os_post)
+        res = host.run(cmd)
+        sub = json.loads(res.stdout)
+        if sub['gateway_ip']:
+            # ping out
+            cmd = "{} -- bash -c 'ip netns exec qdhcp-{} \
+                   ssh -o StrictHostKeyChecking=no rpc_support ubuntu@{} \
+                   ping -c1 -w2 8.8.8.8'".format(lxc_pre, network['id'], ip)
+            host.run_expect([0], cmd)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
 # tasks file for molecule-rpc-openstack-post-deploy
+- import_tasks: support_key.yml
 - name: Install "openvswitch-switch" package
   apt:
      name: openvswitch-switch

--- a/tasks/support_key.yml
+++ b/tasks/support_key.yml
@@ -1,0 +1,64 @@
+---
+- name: Check for key file
+  stat:
+    path: /root/.ssh/rpc_support
+  changed_when: false
+  failed_when: false
+  register: support_key_check
+
+- name: Create support SSH key
+  command: |
+    ssh-keygen -f "/root/.ssh/rpc_support" -t rsa -q -N ""
+  register: support_key_create
+  changed_when: support_key_create.rc == 0
+  failed_when: support_key_create.rc >= 1
+  when: not support_key_check.stat.exists |bool
+
+- name: Get contents of support SSH key
+  slurp:
+    src: "/root/.ssh/rpc_support"
+  register: support_key
+  when: support_key_check.stat.exists |bool or support_key_create|changed
+
+- name: Get contents of support SSH pub key
+  slurp:
+    src: "/root/.ssh/rpc_support.pub"
+  register: support_pub_key
+  when: support_key_check.stat.exists |bool or support_key_create|changed
+
+- name: Get fingerprint of rpc_support SSH key
+  shell: |
+    ssh-keygen -lf /root/.ssh/rpc_support.pub |awk '/(RSA|DSA)/ {print $2}'
+  register: support_key_fingerprint
+  changed_when: support_key_fingerprint.rc == 0
+  failed_when: false
+  when: support_key_check.stat.exists |bool or support_key_create|changed
+
+- name: Check for support keypair in nova
+  shell: |
+    . /root/openrc
+    {{ ops_pip_venv_enabled | bool | ternary(ops_venv, omit) }}/bin/nova keypair-list | grep rpc_support
+  register: nova_support_key
+  changed_when: false
+  failed_when: false
+
+- name: Delete support keypair in nova
+  shell: |
+    . /root/openrc
+    {{ ops_pip_venv_enabled | bool | ternary(ops_venv, omit) }}/bin/nova keypair-delete rpc_support
+  register: nova_support_key_delete
+  changed_when: nova_support_key_delete.rc == 0
+  failed_when: false
+  retries: 2
+  delay: 10
+  when: nova_support_key.rc == 0 and support_key_fingerprint.stdout not in nova_support_key.stdout
+
+- name: Add support key to nova
+  shell: |
+    . /root/openrc
+    {{ ops_pip_venv_enabled | bool | ternary(ops_venv, omit) }}/bin/nova keypair-add --pub-key /root/.ssh/rpc_support.pub rpc_support
+  retries: 2
+  delay: 10
+  when: nova_support_key_delete|changed or nova_support_key.rc == 1
+  vars_files:
+    - "vars/main.yml"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,3 @@
 ---
 # vars file for molecule-rpc-openstack-post-deploy
+ops_pip_venv_enabled: false


### PR DESCRIPTION
This commit implements the `rpc-instance-per-network-per-hypervisor`
test from openstack-ops `pccommon.sh` script. It validates that a server
instance per network, per hypervisor has proper external network connectivity.