### PR TITLE
MAINT - Fix syntax error in molecule create

### DIFF
--- a/molecule/default/create.yml
+++ b/molecule/default/create.yml
@@ -23,6 +23,7 @@
           'user': {{ }},
           'port': "{{ }}",
           'identity_file': "{{ }}",
+        }
       with_items: "{{ server.results }}"
       register: instance_config_dict
       when: server.changed | bool


### PR DESCRIPTION
This commit fixes a syntax error in the molecule create playbook. This
error was introduced by the default molecule cookie cutter template.