### PR TITLE
ASC-572 Skip instance_per_network_per_hypervisor

### DIFF
--- a/molecule/default/tests/test_instance_per_network_per_hypervisor.py
+++ b/molecule/default/tests/test_instance_per_network_per_hypervisor.py
@@ -43,6 +43,7 @@ def create_flavor_on(target_host, flavor):
                                                     os_post))
 
 
+@pytest.mark.skip(reason='ASC-639 No Ubuntu images in image list on Newton')
 @pytest.mark.test_id('c3002bde-59f1-11e8-be3b-6c96cfdb252f')
 @pytest.mark.jira('ASC-241')
 def test_hypervisor_vms(host):


### PR DESCRIPTION
This commit skips the instance_per_network_per_hypervisor.py test.
Currently, this test fails on newton and newton-rc installations due to
the `openstack image list` command not returning any Ubuntu images.

Further research is required to determine the root cause of this failure
and to fix it. This work has been captured in ASC-639.