### PR TITLE
ASC-636 Prioritize openvswitch install

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 # tasks file for molecule-rpc-openstack-post-deploy
-- import_tasks: support_key.yml
 - name: Install "openvswitch-switch" package
   apt:
      name: openvswitch-switch
+- import_tasks: support_key.yml


### PR DESCRIPTION
This commit prioritizes openvswitch installation in order to ensure it
is not skipped if there is a failure in additional tasks. This
prioritization is done specifically so that the `test_dead_taps.py`
test will execute atomically from other test requirements.