### PR TITLE
ASC-324 Add tests for OSA and RPC versions

### DIFF
--- a/molecule/default/tests/test_for_acs-150.py
+++ b/molecule/default/tests/test_for_acs-150.py
@@ -24,12 +24,6 @@ class TestForRPC10PlusPostDeploymentQCProcess(object):
     def test_verify_galera_cluster(self, host):
         """See RPC 10+ Post-Deployment QC process document"""
 
-    @pytest.mark.test_id('d7fc32ba-432a-11e8-81d4-6a00035510c0')
-    @pytest.mark.skip(reason='Need implementation')
-    @pytest.mark.jira('ASC-150')
-    def test_verify_rpc_version(self, host):
-        """See RPC 10+ Post-Deployment QC process document"""
-
     @pytest.mark.test_id('d7fc3423-432a-11e8-aaa8-6a00035510c0')
     @pytest.mark.skip(reason='Need implementation')
     @pytest.mark.jira('ASC-150')

--- a/molecule/default/tests/test_rpc_version.py
+++ b/molecule/default/tests/test_rpc_version.py
@@ -1,0 +1,61 @@
+import os
+import testinfra.utils.ansible_runner
+import pytest
+import re
+import pytest_rpc.helpers as helpers
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('os-infra_hosts')[:1]
+
+expected_codename, expected_major = helpers.get_version_tuple()
+
+
+@pytest.mark.test_id('2c596d8f-7957-11e8-8017-6a00035510c0')
+@pytest.mark.jira('ASC-234')
+def test_openstack_release_version(host):
+    """Test to verify expected version of installed OpenStack
+
+    Args:
+        host(testinfra.host.Host): host fixture that will iterate over
+        testinfra_hosts
+    """
+
+    # Expected example:
+    # DISTRIB_RELEASE="r16.2.0"
+    expected_regex = r'DISTRIB_RELEASE="[r]' + expected_major + r'.\d+.\d+"'
+    release = host.file('/etc/openstack-release').content
+    assert re.search(expected_regex, release)
+
+
+@pytest.mark.test_id('0d8e4105-789e-11e8-8335-6a00035510c0')
+@pytest.mark.jira('ASC-234')
+def test_openstack_codename(host):
+    """Test to verify expected codename of installed OpenStack
+
+    Args:
+        host(testinfra.host.Host): host fixture that will iterate over
+        testinfra_hosts
+    """
+
+    # Expected example:
+    # DISTRIB_CODENAME="Pike"
+    expected_regex = r'DISTRIB_CODENAME="' + expected_codename + r'"'
+    release = host.file('/etc/openstack-release').content
+    assert re.search(expected_regex, release)
+
+
+@pytest.mark.test_id('d7fc32ba-432a-11e8-81d4-6a00035510c0')
+@pytest.mark.jira('ASC-234')
+def test_rpc_version(host):
+    """Test to verify expected version of installed RPC-OpenStack
+
+    Args:
+        host(testinfra.host.Host): host fixture that will iterate over
+        testinfra_hosts
+    """
+
+    # Expected example:
+    # r13.1.0rc1-987-gbb6b806
+    expected_regex = r'[r]' + expected_major + r'.\d+.\d+'
+    res = host.run("cd /opt/rpc-openstack ; git describe --tags")
+    assert re.search(expected_regex, res.stdout)


### PR DESCRIPTION
This commit adds tests to validate the expected versions of OSA and RPC
were installed.

This implements manual test number 5 on the
[Post-Deploy QC Process document](https://one.rackspace.com/pages/viewpage.action?pageId=110992052)