### PR TITLE
ASC-241 use converged resources in test

### DIFF
--- a/molecule/default/tests/test_instance_per_network_per_hypervisor.py
+++ b/molecule/default/tests/test_instance_per_network_per_hypervisor.py
@@ -3,7 +3,8 @@ import testinfra.utils.ansible_runner
 import pytest
 import random
 import json
-import time
+import pytest_rpc.helpers as helpers
+from time import sleep
 
 """ASC-241: Per network, spin up an instance on each hypervisor, perform
 external ping, and tear-down """
@@ -16,7 +17,6 @@ os_pre = ("lxc-attach -n $(lxc-ls -1 | grep utility | head -n 1) "
 os_post = "'"
 
 
-@pytest.fixture
 def create_server_on(target_host, image_id, flavor, network_id, compute_zone, server_name):
     cmd = "{} server create \
            -f json \
@@ -24,23 +24,12 @@ def create_server_on(target_host, image_id, flavor, network_id, compute_zone, se
            --flavor {} \
            --nic net-id={} \
            --availability-zone {} \
+           --key-name 'rpc_support' \
            {} {}".format(os_pre, image_id, flavor,
                          network_id, compute_zone, server_name, os_post)
     res = target_host.run(cmd)
     server = json.loads(res.stdout)
-    yield server
-    target_host.run("{} server delete {} {}".format(os_pre, server['id'],
-                                                    os_post))
-
-
-@pytest.fixture
-def create_flavor_on(target_host, flavor):
-    flavor_cmd = "{} flavor create --ram 512 --disk 10 \
-                  --vcpus 1 {} {}".format(os_pre, flavor, os_post)
-    target_host.run_expect([0], flavor_cmd)
-    yield
-    target_host.run("{} flavor delete {} {}".format(os_pre, flavor,
-                                                    os_post))
+    return server
 
 
 @pytest.mark.test_id('c3002bde-59f1-11e8-be3b-6c96cfdb252f')
@@ -49,25 +38,33 @@ def test_hypervisor_vms(host):
     """ASC-241: Per network, spin up an instance on each hypervisor, perform
     external ping, and tear-down """
 
+    ssh = "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+           -i ~/.ssh/rpc_support ubuntu@{}"
+
+    flavor_name = 'post-deploy'  # look up from ansible values
+    image_name = 'Ubuntu 16.04'  # look up from ansible values
+
     server_list = []
-    # get image id
+    testable_networks = []
+
+    # get image id (sounds like a helper, or register it as an ansible value)
     cmd = "{} image list -f json {}".format(os_pre, os_post)
     res = host.run(cmd)
     images = json.loads(res.stdout)
     assert len(images) > 0
-    filtered_images = list(filter(lambda d: 'buntu' in d['Name'], images))
+    filtered_images = list(filter(lambda d: d['Name'] == image_name, images))
     assert len(filtered_images) > 0
     image = filtered_images[-1]
 
+    # formulate lsc_pre
     cmd = "lxc-ls -1 | egrep 'neutron(_|-)agents' | tail -1"
     res = host.run(cmd)
     container = res.stdout.strip()
     lxc_pre = "lxc-attach -n {} ".format(container)
 
     r = random.randint(1111, 9999)
-    flavor = "rpctest-{}-flavor".format(r)
-    create_flavor_on(host, flavor)
 
+    # get list of internal networks
     net_cmd = "{} network list -f json {}".format(os_pre, os_post)
     net_res = host.run(net_cmd)
     networks = json.loads(net_res.stdout)
@@ -78,6 +75,13 @@ def test_hypervisor_vms(host):
         network_detail = json.loads(res.stdout)
         if network_detail['router:external'] == 'External':
             continue
+        testable_networks.append(network_detail)
+
+    if not testable_networks:
+        pytest.skip("No testable networks found")
+
+    # iterate over internal networks
+    for network in testable_networks:
         # spin up instance per hypervisor
         cmd = "{} compute service list -f json {}".format(os_pre, os_post)
         res = host.run(cmd)
@@ -85,24 +89,22 @@ def test_hypervisor_vms(host):
         for compute in computes:
             if compute['Binary'] == 'nova-compute':
                 instance_name = "rpctest-{}-{}-{}".format(r, compute['Host'],
-                                                          network_detail['name'])
-                server = create_server_on(host, image['ID'], flavor,
-                                          network['ID'], compute['Zone'],
+                                                          network['name'])
+                server = create_server_on(host, image['ID'], flavor_name,
+                                          network['id'], compute['Zone'],
                                           instance_name)
-                server_list.append(server)
-
-    # sleep to allow servers to boot
-    time.sleep(60)
+                assert helpers.get_expected_value('server', server['id'],
+                                                  'status', 'ACTIVE', host, 15)
+                server_list.append(server['id'])
 
     for server in server_list:
-        cmd = "{} server show {} -f json {}".format(os_pre, server['id'],
-                                                    os_post)
-        res = host.run(cmd)
-        s = json.loads(res.stdout)
-        assert s['status'] == 'ACTIVE'
-
         # test ssh
-        network_name, ip = s['addresses'].split('=')
+        print "DEBUG OUTPUT"
+        print server
+        cmd = "{} server show {} -f json {}".format(os_pre, server, os_post)
+        res = host.run(cmd)
+        server_detail = json.loads(res.stdout)
+        network_name, ip = server_detail['addresses'].split('=')
         # get network detail (again)
         # This will include network id and subnets.
         cmd = "{} network show {} -f json {}".format(os_pre, network_name,
@@ -112,11 +114,18 @@ def test_hypervisor_vms(host):
 
         # confirm SSH port access
         cmd = "{} -- bash \
-               -c 'ip netns exec qdhcp-{} nc -w1 {} 22'".format(lxc_pre,
-                                                                network['id'],
-                                                                ip)
-        res = host.run(cmd)
-        assert 'SSH' in res.stdout
+               -c 'ip netns exec \
+               qdhcp-{} nc -w1 {} 22'".format(lxc_pre, network['id'], ip)
+        for attempt in range(10):
+            res = host.run(cmd)
+            try:
+                assert 'SSH' in res.stdout
+            except AssertionError:
+                sleep(10)
+            else:
+                break
+        else:
+            assert 'SSH' in res.stdout
 
         # get gateway ip via subnet detail
         cmd = "{} subnet show {} -f json {}".format(os_pre,
@@ -126,6 +135,5 @@ def test_hypervisor_vms(host):
         if sub['gateway_ip']:
             # ping out
             cmd = "{} -- bash -c 'ip netns exec qdhcp-{} \
-                   ssh -o StrictHostKeyChecking=no rpc_support ubuntu@{} \
-                   ping -c1 -w2 8.8.8.8'".format(lxc_pre, network['id'], ip)
+                   {} ping -c1 -w2 8.8.8.8'".format(lxc_pre, network['id'], ssh.format(ip))
             host.run_expect([0], cmd)

--- a/tasks/flavor_setup.yml
+++ b/tasks/flavor_setup.yml
@@ -1,3 +1,4 @@
+---
 - name: Check for flavor in nova
   shell: |
     lxc-attach -n {{ utility_container.stdout }}  \

--- a/tasks/image_setup.yml
+++ b/tasks/image_setup.yml
@@ -1,3 +1,4 @@
+---
 - name: Check for image in glance
   shell: |
     lxc-attach -n {{ utility_container.stdout }}  \

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,3 +8,4 @@
 - include_tasks: flavor_setup.yml
 - include_tasks: server_setup.yml
 - include_tasks: volume_setup.yml
+- include_tasks: network_setup.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,7 @@
   apt:
      name: openvswitch-switch
 - import_tasks: support_key.yml
+- include_tasks: security_group_setup.yml
 - include_tasks: image_setup.yml
 - include_tasks: flavor_setup.yml
 - include_tasks: server_setup.yml

--- a/tasks/network_setup.yml
+++ b/tasks/network_setup.yml
@@ -1,4 +1,6 @@
 ---
+# openstack router unset --external-gateway  TEST-ROUTER
+# ^^^ allows gateway subnet to be deleted
 - name: Check for test router
   shell: |
     lxc-attach -n {{ utility_container.stdout }}  \
@@ -8,6 +10,59 @@
   changed_when: false
   failed_when: false
 
+- name: Check for gateway subnet
+  shell: |
+    lxc-attach -n {{ utility_container.stdout }}  \
+    -- bash -c '. /root/openrc ; \
+    openstack subnet list | grep GATEWAY_NET_SUBNET'
+  register: test_gateway_subnet_instance
+  changed_when: false
+  failed_when: false
+
+- name: Check for gateway network
+  shell: |
+    lxc-attach -n {{ utility_container.stdout }}  \
+    -- bash -c '. /root/openrc ; \
+    openstack network list | grep GATEWAY_NET'
+  register: test_gateway_network_instance
+  changed_when: false
+  failed_when: false
+
+- name: Create gateway network
+  # Needed params for public net?
+  # network-type flat?
+  # router:external internal?
+  # openstack network create --external TEST-GATEWAY
+  # openstack network create --provider-network-type vlan  --provider-physical-network vlan TEST-GATEWAY
+  shell: |
+    lxc-attach -n {{ utility_container.stdout }} \
+    -- bash -c '. /root/openrc ; \
+    openstack network create \
+    -f json \
+    --shared \
+    --external \
+    --provider-network-type flat \
+    --provider-physical-network flat \
+    GATEWAY_NET'
+  when: test_gateway_network_instance.rc != 0
+
+- name: Create gateway subnet
+  # Needed params for public net?
+  # openstack subnet create --subnet-range 192.168.42.0/24 --network TEST-GATEWAY --dns-nameserver 8.8.8.8 TEST-GATEWAY-SUBNET
+  shell: |
+    lxc-attach -n {{ utility_container.stdout }} \
+    -- bash -c '. /root/openrc ; \
+    openstack subnet create \
+    --ip-version 4 \
+    --subnet-range 10.0.248.0/22 \
+    --gateway 10.0.248.1 \
+    --allocation-pool start=10.0.248.201,end=10.0.48.255 \
+    --network GATEWAY_NET \
+    --dns-nameserver 8.8.8.8 \
+    --no-dhcp \
+    GATEWAY_NET_SUBNET'
+  when: test_gateway_subnet_instance.rc != 0
+#
 - name: Check for test subnet
   shell: |
     lxc-attach -n {{ utility_container.stdout }}  \
@@ -16,30 +71,6 @@
   register: test_subnet_instance
   changed_when: false
   failed_when: false
-
-- name: Remove subnet from router
-  shell: |
-    lxc-attach -n {{ utility_container.stdout }} \
-    -- bash -c '. /root/openrc ; \
-    openstack router remove subnet TEST-ROUTER "{{ test_subnet }}"'
-  when:
-    - test_router_instance.rc == 0
-    - test_subnet_instance.rc == 0
-
-- name: Delete test router
-  shell: |
-    lxc-attach -n {{ utility_container.stdout }} \
-    -- bash -c '. /root/openrc ; \
-    openstack router delete \
-    TEST-ROUTER'
-  when: test_router_instance.rc == 0
-
-- name: Delete test subnet
-  shell: |
-    lxc-attach -n {{ utility_container.stdout }}  \
-    -- bash -c '. /root/openrc ; \
-    openstack subnet delete "{{ test_subnet }}"'
-  when: test_subnet_instance.rc == 0
 
 - name: Check for test network
   shell: |
@@ -50,13 +81,6 @@
   changed_when: false
   failed_when: false
 
-- name: Delete test network
-  shell: |
-    lxc-attach -n {{ utility_container.stdout }}  \
-    -- bash -c '. /root/openrc ; \
-    openstack network delete "{{ test_network }}"'
-  when: test_network_instance.rc == 0
-
 - name: Create test network
   shell: |
     lxc-attach -n {{ utility_container.stdout }} \
@@ -64,6 +88,7 @@
     openstack network create \
     -f json \
     "{{ test_network }}"'
+  when: test_network_instance.rc != 0
 
 - name: Create test subnet
   shell: |
@@ -75,6 +100,7 @@
     --subnet-range 192.168.1.0/24 \
     --network "{{ test_network }}" \
     "{{ test_subnet }}"'
+  when: test_subnet_instance.rc != 0
 
 - name: Create test router
   shell: |
@@ -82,12 +108,14 @@
     -- bash -c '. /root/openrc ; \
     openstack router create \
     TEST-ROUTER'
+  when: test_router_instance.rc != 0
 
 - name: Add subnet to router
   shell: |
     lxc-attach -n {{ utility_container.stdout }} \
     -- bash -c '. /root/openrc ; \
     openstack router add subnet TEST-ROUTER "{{ test_subnet }}"'
+  when: test_router_instance.rc != 0
 
 - name: Set external gateway on router
   # Note this will not work in production since the GATEWAY_NET network has
@@ -96,3 +124,4 @@
     lxc-attach -n {{ utility_container.stdout }} \
     -- bash -c '. /root/openrc ; \
     openstack router set --external-gateway GATEWAY_NET TEST-ROUTER'
+  when: test_router_instance.rc != 0

--- a/tasks/network_setup.yml
+++ b/tasks/network_setup.yml
@@ -1,4 +1,13 @@
 ---
+- name: Check for test router
+  shell: |
+    lxc-attach -n {{ utility_container.stdout }}  \
+    -- bash -c '. /root/openrc ; \
+    openstack router list | grep TEST-ROUTER'
+  register: test_router_instance
+  changed_when: false
+  failed_when: false
+
 - name: Check for test subnet
   shell: |
     lxc-attach -n {{ utility_container.stdout }}  \
@@ -7,6 +16,23 @@
   register: test_subnet_instance
   changed_when: false
   failed_when: false
+
+- name: Remove subnet from router
+  shell: |
+    lxc-attach -n {{ utility_container.stdout }} \
+    -- bash -c '. /root/openrc ; \
+    openstack router remove subnet TEST-ROUTER "{{ test_subnet }}"'
+  when:
+    - test_router_instance.rc == 0
+    - test_subnet_instance.rc == 0
+
+- name: Delete test router
+  shell: |
+    lxc-attach -n {{ utility_container.stdout }} \
+    -- bash -c '. /root/openrc ; \
+    openstack router delete \
+    TEST-ROUTER'
+  when: test_router_instance.rc == 0
 
 - name: Delete test subnet
   shell: |
@@ -49,3 +75,24 @@
     --subnet-range 192.168.1.0/24 \
     --network "{{ test_network }}" \
     "{{ test_subnet }}"'
+
+- name: Create test router
+  shell: |
+    lxc-attach -n {{ utility_container.stdout }} \
+    -- bash -c '. /root/openrc ; \
+    openstack router create \
+    TEST-ROUTER'
+
+- name: Add subnet to router
+  shell: |
+    lxc-attach -n {{ utility_container.stdout }} \
+    -- bash -c '. /root/openrc ; \
+    openstack router add subnet TEST-ROUTER "{{ test_subnet }}"'
+
+- name: Set external gateway on router
+  # Note this will not work in production since the GATEWAY_NET network has
+  # not been created by this molecule.
+  shell: |
+    lxc-attach -n {{ utility_container.stdout }} \
+    -- bash -c '. /root/openrc ; \
+    openstack router set --external-gateway GATEWAY_NET TEST-ROUTER'

--- a/tasks/network_setup.yml
+++ b/tasks/network_setup.yml
@@ -1,0 +1,51 @@
+---
+- name: Check for test subnet
+  shell: |
+    lxc-attach -n {{ utility_container.stdout }}  \
+    -- bash -c '. /root/openrc ; \
+    openstack subnet list | grep "{{ test_subnet }}"'
+  register: test_subnet_instance
+  changed_when: false
+  failed_when: false
+
+- name: Delete test subnet
+  shell: |
+    lxc-attach -n {{ utility_container.stdout }}  \
+    -- bash -c '. /root/openrc ; \
+    openstack subnet delete "{{ test_subnet }}"'
+  when: test_subnet_instance.rc == 0
+
+- name: Check for test network
+  shell: |
+    lxc-attach -n {{ utility_container.stdout }}  \
+    -- bash -c '. /root/openrc ; \
+    openstack network list | grep "{{ test_network }}"'
+  register: test_network_instance
+  changed_when: false
+  failed_when: false
+
+- name: Delete test network
+  shell: |
+    lxc-attach -n {{ utility_container.stdout }}  \
+    -- bash -c '. /root/openrc ; \
+    openstack network delete "{{ test_network }}"'
+  when: test_network_instance.rc == 0
+
+- name: Create test network
+  shell: |
+    lxc-attach -n {{ utility_container.stdout }} \
+    -- bash -c '. /root/openrc ; \
+    openstack network create \
+    -f json \
+    "{{ test_network }}"'
+
+- name: Create test subnet
+  shell: |
+    lxc-attach -n {{ utility_container.stdout }} \
+    -- bash -c '. /root/openrc ; \
+    openstack subnet create \
+    --allocation-pool start=192.168.1.2,end=192.168.1.254 \
+    --host-route destination=0.0.0.0/0,gateway=192.168.1.1 \
+    --subnet-range 192.168.1.0/24 \
+    --network "{{ test_network }}" \
+    "{{ test_subnet }}"'

--- a/tasks/security_group_setup.yml
+++ b/tasks/security_group_setup.yml
@@ -1,0 +1,49 @@
+---
+- name: Check for rpc_support security group
+  shell: |
+    lxc-attach -n {{ utility_container.stdout }} \
+    -- bash -c '. /root/openrc ; \
+    openstack security group list | grep -w "rpc-support"'
+  register: rpc_support_sec_group
+  changed_when: false
+  failed_when: rpc_support_sec_group.rc not in [0, 1]
+
+- name: Create rpc_support security group
+  shell: |
+    lxc-attach -n {{ utility_container.stdout }} \
+    -- bash -c '. /root/openrc ; \
+    openstack security group create rpc-support'
+  register: sec_group_create
+  changed_when: sec_group_create.rc == 0
+  failed_when: sec_group_create.rc != 0
+  when: rpc_support_sec_group.rc != 0
+
+- name: Create rpc_support security group rules ports
+  shell: |
+    lxc-attach -n {{ utility_container.stdout }} \
+    -- bash -c '. /root/openrc ; \
+    openstack security group rule create \
+            --ingress \
+            --protocol tcp \
+            --dst-port {{ item }} \
+            --remote-ip 0.0.0.0/0 \
+            rpc-support'
+  register: sec_group_rules_ports
+  changed_when: sec_group_rules_ports.rc == 0
+  when: sec_group_create|changed
+  with_items:
+    - 22
+    - 3389
+
+- name: Create rpc_support security group rules icmp
+  shell: |
+    lxc-attach -n {{ utility_container.stdout }} \
+    -- bash -c '. /root/openrc ; \
+    openstack security group rule create \
+            --ingress \
+            --protocol icmp \
+            --remote-ip 0.0.0.0/0 \
+            rpc-support'
+  register: sec_group_rules_icmp
+  changed_when: sec_group_rules_icmp.rc == 0
+  when: sec_group_create|changed

--- a/tasks/server_setup.yml
+++ b/tasks/server_setup.yml
@@ -1,19 +1,20 @@
 ---
-- name: Check for test server
+- name: Check for servers
   shell: |
     lxc-attach -n {{ utility_container.stdout }}  \
     -- bash -c '. /root/openrc ; \
-    openstack server list | grep "{{ test_server }}"'
-  register: test_server_instance
+    openstack server list -c ID -f value'
+  register: server_instances
   changed_when: false
   failed_when: false
 
-- name: Delete test server
+- name: Delete all servers
   shell: |
     lxc-attach -n {{ utility_container.stdout }}  \
     -- bash -c '. /root/openrc ; \
-    openstack server delete "{{ test_server }}"'
-  when: test_server_instance.rc == 0
+    openstack server delete "{{ item }}"'
+  when: server_instances.rc == 0
+  with_items: "{{ server_instances.stdout_lines }}"
 
 - name: Create test server
   shell: |

--- a/tasks/server_setup.yml
+++ b/tasks/server_setup.yml
@@ -1,3 +1,4 @@
+---
 - name: Check for test server
   shell: |
     lxc-attach -n {{ utility_container.stdout }}  \

--- a/tasks/support_key.yml
+++ b/tasks/support_key.yml
@@ -4,6 +4,11 @@
     lxc-ls -1 | grep utility | head -n 1
   register: utility_container
 
+- name: Register neutron container
+  shell: |
+    lxc-ls -1 | egrep 'neutron(_|-)agents' | tail -1
+  register: neutron_container
+
 - name: Install packages required for RPC support
   apt:
     pkg: "{{ item }}"
@@ -75,6 +80,10 @@
     - dest: "/var/lib/lxc/{{ utility_container.stdout }}/rootfs/root/.ssh/rpc_support"
       content: "{{ support_key.content | b64decode }}"
     - dest: "/var/lib/lxc/{{ utility_container.stdout }}/rootfs/root/.ssh/rpc_support.pub"
+      content: "{{ support_pub_key.content | b64decode }}"
+    - dest: "/var/lib/lxc/{{ neutron_container.stdout }}/rootfs/root/.ssh/rpc_support"
+      content: "{{ support_key.content | b64decode }}"
+    - dest: "/var/lib/lxc/{{ neutron_container.stdout }}/rootfs/root/.ssh/rpc_support.pub"
       content: "{{ support_pub_key.content | b64decode }}"
   when:
     - support_pub_key.content |default('') |length > 64

--- a/tasks/support_key.yml
+++ b/tasks/support_key.yml
@@ -1,5 +1,5 @@
 ---
-- name: Register utility contaier
+- name: Register utility container
   shell: |
     lxc-ls -1 | grep utility | head -n 1
   register: utility_container
@@ -8,9 +8,9 @@
   apt:
     pkg: "{{ item }}"
     state: present
-    update_cache: yes
+    update_cache: true
     cache_valid_time: 600
-    force: yes
+    force: true
   with_items: "{{ ops_apt_util_packages }}"
   when:
     - ansible_os_family == 'Debian'
@@ -23,7 +23,7 @@
   apt:
     pkg: "{{ item }}"
     state: present
-    update_cache: yes
+    update_cache: true
     cache_valid_time: 600
   with_items: "{{ ops_apt_host_packages }}"
   when:

--- a/tasks/volume_setup.yml
+++ b/tasks/volume_setup.yml
@@ -1,3 +1,4 @@
+---
 - name: Check for test volume
   shell: |
     lxc-attach -n {{ utility_container.stdout }}  \

--- a/tasks/volume_setup.yml
+++ b/tasks/volume_setup.yml
@@ -25,7 +25,9 @@
     lxc-attach -n {{ utility_container.stdout }}  \
     -- bash -c '. /root/openrc ; \
     openstack volume delete "{{ test_volume }}"'
-  when: test_volume_status.stdout.strip().lower() == 'available'
+  when:
+    - test_volume_instance.rc == 0
+    - test_volume_status.stdout is defined and test_volume_status.stdout.strip().lower() == 'available'
 
 - name: Create test volume
   shell: |

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -29,3 +29,5 @@ flavor:
   name: post-deploy
 test_server: post-deploy-server
 test_volume: post-deploy-volume
+test_network: TEST-VXLAN
+test_subnet: TEST-VXLAN-SUBNET


### PR DESCRIPTION
This PR updates the instance_per_network_per_hypervisor test to use
the resources created during the converge step rather than the
'fixtures' that were previously defined.