### PR TITLE
ASC-241 Delete servers before network setup

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,7 @@
 - include_tasks: security_group_setup.yml
 - include_tasks: image_setup.yml
 - include_tasks: flavor_setup.yml
+- include_tasks: server_delete.yml
+- include_tasks: network_setup.yml
 - include_tasks: server_setup.yml
 - include_tasks: volume_setup.yml
-- include_tasks: network_setup.yml

--- a/tasks/server_delete.yml
+++ b/tasks/server_delete.yml
@@ -1,0 +1,19 @@
+---
+- name: Check for servers
+  shell: |
+    lxc-attach -n {{ utility_container.stdout }}  \
+    -- bash -c '. /root/openrc ; \
+    openstack server list -c ID -f value'
+  register: server_instances
+  changed_when: false
+  failed_when: false
+
+- name: Delete all servers
+  shell: |
+    lxc-attach -n {{ utility_container.stdout }}  \
+    -- bash -c '. /root/openrc ; \
+    openstack server delete "{{ item }}"'
+  when:
+    - server_instances.rc == 0
+    - server_instances.stdout_lines not empty
+  with_items: "{{ server_instances.stdout_lines }}"

--- a/tasks/server_setup.yml
+++ b/tasks/server_setup.yml
@@ -1,21 +1,4 @@
 ---
-- name: Check for servers
-  shell: |
-    lxc-attach -n {{ utility_container.stdout }}  \
-    -- bash -c '. /root/openrc ; \
-    openstack server list -c ID -f value'
-  register: server_instances
-  changed_when: false
-  failed_when: false
-
-- name: Delete all servers
-  shell: |
-    lxc-attach -n {{ utility_container.stdout }}  \
-    -- bash -c '. /root/openrc ; \
-    openstack server delete "{{ item }}"'
-  when: server_instances.rc == 0
-  with_items: "{{ server_instances.stdout_lines }}"
-
 - name: Create test server
   shell: |
     lxc-attach -n {{ utility_container.stdout }} \

--- a/tasks/server_setup.yml
+++ b/tasks/server_setup.yml
@@ -7,6 +7,6 @@
     -f json \
     --image "{{ image.name }}" \
     --flavor "{{ flavor.name }}" \
-    --nic net-id="PRIVATE_NET" \
+    --nic net-id="{{ test_network }}" \
     --key-name "rpc_support" \
     "{{ test_server }}"'


### PR DESCRIPTION
This commit fixes a logical error in the ordering of the ansible
OpenStack setup operations. This change ensures that all servers are
deleted prior to the network setup. This frees the network from any IP
bindings prior to delete/create. The network setup then happens prior to
server creation ensuring that the test network is available to bind to
prior to server creation.