### PR TITLE
ASC-297 Delete swift fully rebalanced test

### DIFF
--- a/molecule/default/tests/test_for_acs-295.py
+++ b/molecule/default/tests/test_for_acs-295.py
@@ -12,12 +12,6 @@ class TestForRPC10PlusPostDeploymentQCProcessSwift(object):
      https://rpc-openstack.atlassian.net/browse/ASC-295
      """
 
-    @pytest.mark.test_id('d7fc480f-432a-11e8-937e-6a00035510c0')
-    @pytest.mark.skip(reason='Need implementation')
-    @pytest.mark.jira('ASC-295')
-    def test_object_ring_rebalanced(self, host):
-        """See RPC 10+ Post-Deployment QC process document"""
-
     @pytest.mark.test_id('d7fc49a8-432a-11e8-a2ea-6a00035510c0')
     @pytest.mark.skip(reason='Need implementation')
     @pytest.mark.jira('ASC-295')


### PR DESCRIPTION
This commit deletes the "swift full rebalanced" test.

This test is seems like a mitigation step to perform if the previous
balance test does not result in balance values of less than 1.0. It is not
practical to wait 'a few hours' when running automated tests to validate that
the balance has reached a 0.00 value across all devices.