### PR TITLE
ASC-241 Connect neutron-agent container/baremetal

### DIFF
--- a/molecule/default/tests/test_instance_per_network_per_hypervisor.py
+++ b/molecule/default/tests/test_instance_per_network_per_hypervisor.py
@@ -41,8 +41,11 @@ def test_hypervisor_vms(host):
     ssh = "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
            -i ~/.ssh/rpc_support ubuntu@{}"
 
-    flavor_name = 'post-deploy'  # look up from ansible values
-    image_name = 'Ubuntu 16.04'  # look up from ansible values
+    vars = host.ansible('include_vars',
+                        'file=./vars/main.yml')['ansible_facts']
+
+    flavor_name = vars['flavor']['name']
+    image_name = vars['image']['name']
 
     server_list = []
     testable_networks = []

--- a/molecule/default/tests/test_instance_per_network_per_hypervisor.py
+++ b/molecule/default/tests/test_instance_per_network_per_hypervisor.py
@@ -56,11 +56,21 @@ def test_hypervisor_vms(host):
     assert len(filtered_images) > 0
     image = filtered_images[-1]
 
-    # formulate lsc_pre
-    cmd = "lxc-ls -1 | egrep 'neutron(_|-)agents' | tail -1"
-    res = host.run(cmd)
-    container = res.stdout.strip()
-    lxc_pre = "lxc-attach -n {} ".format(container)
+    # neutron_agent connection lookup
+    na_list = testinfra.utils.ansible_runner.AnsibleRunner(
+        os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('neutron_agent')
+    hostname = host.check_output('hostname')
+    na_list = [x for x in na_list if hostname in x]
+    neutron_agent = next(iter(na_list), None)
+    assert neutron_agent
+    if 'container' in neutron_agent:
+        # lxc
+        na_pre = "lxc-attach -n {} -- bash -c ".format(neutron_agent)
+    else:
+        # ssh
+        na_pre = "ssh -o StrictHostKeyChecking=no \
+                   -o UserKnownHostsFile=/dev/null \
+                   {} ".format(neutron_agent)
 
     r = random.randint(1111, 9999)
 
@@ -113,9 +123,8 @@ def test_hypervisor_vms(host):
         network = json.loads(res.stdout)
 
         # confirm SSH port access
-        cmd = "{} -- bash \
-               -c 'ip netns exec \
-               qdhcp-{} nc -w1 {} 22'".format(lxc_pre, network['id'], ip)
+        cmd = "{} 'ip netns exec \
+               qdhcp-{} nc -w1 {} 22'".format(na_pre, network['id'], ip)
         for attempt in range(10):
             res = host.run(cmd)
             try:
@@ -134,6 +143,8 @@ def test_hypervisor_vms(host):
         sub = json.loads(res.stdout)
         if sub['gateway_ip']:
             # ping out
-            cmd = "{} -- bash -c 'ip netns exec qdhcp-{} \
-                   {} ping -c1 -w2 8.8.8.8'".format(lxc_pre, network['id'], ssh.format(ip))
+            cmd = "{} 'ip netns exec \
+                   qdhcp-{} {} ping -c1 -w2 8.8.8.8'".format(na_pre,
+                                                             network['id'],
+                                                             ssh.format(ip))
             host.run_expect([0], cmd)

--- a/tasks/support_key.yml
+++ b/tasks/support_key.yml
@@ -4,11 +4,6 @@
     lxc-ls -1 | grep utility | head -n 1
   register: utility_container
 
-- name: Register neutron container
-  shell: |
-    lxc-ls -1 | egrep 'neutron(_|-)agents' | tail -1
-  register: neutron_container
-
 - name: Install packages required for RPC support
   apt:
     pkg: "{{ item }}"
@@ -69,22 +64,29 @@
   failed_when: false
   when: support_key_check.stat.exists |bool or support_key_create|changed
 
-- name: Distribute support SSH key for cluster operations
+- name: Get container rootfs directory list
+  shell: "ls -1 -d /var/lib/lxc/*/rootfs"
+  register: container_rootfs_list
+
+- name: Distribute support SSH private key to containers
   copy:
-    dest: "{{ item.dest }}"
-    content: "{{ item.content }}"
+    dest: "{{ item }}/root/.ssh/rpc_support"
+    content: "{{ support_key.content | b64decode }}"
     owner: "root"
     group: "root"
     mode: "0600"
-  with_items:
-    - dest: "/var/lib/lxc/{{ utility_container.stdout }}/rootfs/root/.ssh/rpc_support"
-      content: "{{ support_key.content | b64decode }}"
-    - dest: "/var/lib/lxc/{{ utility_container.stdout }}/rootfs/root/.ssh/rpc_support.pub"
-      content: "{{ support_pub_key.content | b64decode }}"
-    - dest: "/var/lib/lxc/{{ neutron_container.stdout }}/rootfs/root/.ssh/rpc_support"
-      content: "{{ support_key.content | b64decode }}"
-    - dest: "/var/lib/lxc/{{ neutron_container.stdout }}/rootfs/root/.ssh/rpc_support.pub"
-      content: "{{ support_pub_key.content | b64decode }}"
+  with_items: "{{ container_rootfs_list.stdout_lines }}"
+  when:
+    - support_key.content |default('') |length > 64
+
+- name: Distribute support SSH public key to containers
+  copy:
+    dest: "{{ item }}/root/.ssh/rpc_support.pub"
+    content: "{{ support_pub_key.content | b64decode }}"
+    owner: "root"
+    group: "root"
+    mode: "0600"
+  with_items: "{{ container_rootfs_list.stdout_lines }}"
   when:
     - support_pub_key.content |default('') |length > 64
 


### PR DESCRIPTION
This commit adds logic to the test_instance_per_network_per_hypervisor
test to connect to a neutron-agent whether it has been deployed as a
container or a baremetal host. Prior to this commit it was assumed that
neutron-agent hosts were containers.