### PR TITLE
ASC-241 Fix network create share argument

### DIFF
--- a/tasks/network_setup.yml
+++ b/tasks/network_setup.yml
@@ -39,7 +39,7 @@
     -- bash -c '. /root/openrc ; \
     openstack network create \
     -f json \
-    --shared \
+    --share \
     --external \
     --provider-network-type flat \
     --provider-physical-network flat \


### PR DESCRIPTION
This commit corrects the incorrect `--shared` network create argument to
`--share`.