### PR TITLE
ASC-266 Delete socks proxy access test

### DIFF
--- a/molecule/default/tests/test_for_acs-150.py
+++ b/molecule/default/tests/test_for_acs-150.py
@@ -113,9 +113,3 @@ class TestForRPC10PlusPostDeploymentQCProcess(object):
     @pytest.mark.jira('ASC-150')
     def test_verify_console_horizon(self, host):
         """See RPC 10+ Post-Deployment QC process document"""
-
-    @pytest.mark.test_id('d7fc4407-432a-11e8-b65b-6a00035510c0')
-    @pytest.mark.skip(reason='Need implementation')
-    @pytest.mark.jira('ASC-150')
-    def test_verify_kibana_horizon_access_with_no_ssh(self, host):
-        """See RPC 10+ Post-Deployment QC process document"""


### PR DESCRIPTION
This commit deletes the test stub for the "Verify Kibana and Horizon are
accessible without SSH tunneling" test.

The purpose of this validation is to ensure that a customer deployment
is accessible via the rackspace bastion socks proxy. Since CI
deployments do not occur on a private external network, such a
validation cannot be properly executed in the CI gating jobs. Therefore,
this test is being removed from the suite.