### PR TITLE
(ASC-265) delete UI test case view instance console

### DIFF
--- a/molecule/default/tests/test_for_acs-150.py
+++ b/molecule/default/tests/test_for_acs-150.py
@@ -101,9 +101,3 @@ class TestForRPC10PlusPostDeploymentQCProcess(object):
     @pytest.mark.jira('ASC-150')
     def test_verify_ssl_config_f5(self, host):
         """See RPC 10+ Post-Deployment QC process document"""
-
-    @pytest.mark.test_id('d7fc412e-432a-11e8-ae40-6a00035510c0')
-    @pytest.mark.skip(reason='Need implementation')
-    @pytest.mark.jira('ASC-150')
-    def test_verify_console_horizon(self, host):
-        """See RPC 10+ Post-Deployment QC process document"""


### PR DESCRIPTION
Per asc team's decision, we are not going to do ui testing at this time, so the test case of verifying instance's console in Horizon should be deleted from the list of planned tests