### PR TITLE
ASC-790 Remove external-ip in security group rule

### DIFF
--- a/tasks/security_group_setup.yml
+++ b/tasks/security_group_setup.yml
@@ -26,7 +26,6 @@
             --ingress \
             --protocol tcp \
             --dst-port "{{ item }}" \
-            --remote-ip 0.0.0.0/0 \
             rpc-support'
   register: sec_group_rules_ports
   changed_when: sec_group_rules_ports.rc == 0
@@ -42,7 +41,6 @@
     openstack security group rule create \
             --ingress \
             --protocol icmp \
-            --remote-ip 0.0.0.0/0 \
             rpc-support'
   register: sec_group_rules_icmp
   changed_when: sec_group_rules_icmp.rc == 0


### PR DESCRIPTION
This commit removes the `--external-ip` flag from the security group
rule create commands in the converge tasks. This flag is not available
in the newton version of the openstack cli command and was causing the
execution of this task to fail. Because the flag was being set to its
default value, not having it in newer openstack deploys will not have
any effect on its execution.