### PR TITLE
ASC-792 No explicit DISTRIB_RELEASE if not defined

### DIFF
--- a/molecule/default/tests/test_rpc_version.py
+++ b/molecule/default/tests/test_rpc_version.py
@@ -22,7 +22,11 @@ def test_openstack_release_version(host):
 
     # Expected example:
     # DISTRIB_RELEASE="r16.2.0"
-    expected_regex = r'DISTRIB_RELEASE="[r]' + expected_major + r'.\d+.\d+"'
+    if expected_major.isdigit():
+        pat = expected_major + r'.\d+.\d+'
+    else:
+        pat = r'\w+'
+    expected_regex = re.compile('DISTRIB_RELEASE="r?{}"'.format(pat))
     release = host.file('/etc/openstack-release').content
     assert re.search(expected_regex, release)
 


### PR DESCRIPTION
This commit updates the `openstack_release_version` test to simply
verify that the `DISTRIB_RELEASE` entry is defined and is set to an
alphanumeric value in the case that the explicit major release version
is not defined by the helper.