### PR TITLE
ASC-791 Assert equal for dhcp agent validation

### DIFF
--- a/molecule/default/tests/test_dhcp_agents.py
+++ b/molecule/default/tests/test_dhcp_agents.py
@@ -44,6 +44,6 @@ def test_openvswitch(host):
 
         for agent in results:
             if osa_major > 14:
-                assert agent['State'] is 'UP'
+                assert agent['State'] == 'UP'
             else:
                 assert agent['admin_state_up'] is True


### PR DESCRIPTION
This commit changes the assert syntax from 'a is b' to 'a == b'. Prior
to this commit, the test failed in CI with the following error:

    >                   assert agent['State'] is 'UP'
    E                   AssertionError: assert 'UP' is 'UP'