### PR TITLE
ASC-791 Add local helper for get_osa_version

### DIFF
--- a/molecule/default/tests/test_dhcp_agents.py
+++ b/molecule/default/tests/test_dhcp_agents.py
@@ -31,10 +31,12 @@ def test_openvswitch(host):
 
     expected_codename, expected_major = \
         get_osa_version(os.environ['RE_JOB_BRANCH'])
+    print "expected_major: {}".format(expected_major)
     try:
         osa_major = int(expected_major)
     except ValueError:
         osa_major = 99
+    print "osa_major: {}".format(osa_major)
 
     os_pre = ("lxc-attach -n $(lxc-ls -1 | grep utility | head -n 1) "
               "-- bash -c '. /root/openrc ; openstack ")
@@ -52,6 +54,7 @@ def test_openvswitch(host):
                              "neutron dhcp-agent-list-hosting-net {} "
                              "-f json'".format(network['ID']))
 
+        print net_agent_cmd
         res = host.run(net_agent_cmd)
         results = json.loads(res.stdout)
 

--- a/molecule/default/tests/test_dhcp_agents.py
+++ b/molecule/default/tests/test_dhcp_agents.py
@@ -2,12 +2,24 @@ import os
 import testinfra.utils.ansible_runner
 import pytest
 import json
-import pytest_rpc.helpers as helpers
 
 """ASC-157: Perform Post Deploy System validations"""
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('os-infra_hosts')[:1]
+
+
+def get_osa_version(branch):
+    if branch in ['newton', 'newton-rc']:
+        return ('Newton', '14')
+    elif branch in ['pike', 'pike-rc']:
+        return ('Pike', '16')
+    elif branch in ['queens', 'queens-rc']:
+        return ('Queens', '17')
+    elif branch in ['rocky', 'rocky-rc']:
+        return ('Rocky', '18')
+    else:
+        return ('', '')
 
 
 @pytest.mark.test_id('d7fc25ae-432a-11e8-a20a-6a00035510c0')
@@ -17,9 +29,10 @@ def test_openvswitch(host):
     Ensure DHCP agents for all networks are up
     """
 
-    osa_name, osa_major = helpers.get_osa_version_tuple()
+    expected_codename, expected_major = \
+        get_osa_version(os.environ['RE_JOB_BRANCH'])
     try:
-        osa_major = int(osa_major)
+        osa_major = int(expected_major)
     except ValueError:
         osa_major = 99
 

--- a/molecule/default/tests/test_rpc_version.py
+++ b/molecule/default/tests/test_rpc_version.py
@@ -2,12 +2,26 @@ import os
 import testinfra.utils.ansible_runner
 import pytest
 import re
-import pytest_rpc.helpers as helpers
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('os-infra_hosts')[:1]
 
-expected_codename, expected_major = helpers.get_osa_version_tuple()
+
+def get_osa_version(branch):
+    if branch in ['newton', 'newton-rc']:
+        return ('Newton', '14')
+    elif branch in ['pike', 'pike-rc']:
+        return ('Pike', '16')
+    elif branch in ['queens', 'queens-rc']:
+        return ('Queens', '17')
+    elif branch in ['rocky', 'rocky-rc']:
+        return ('Rocky', '18')
+    else:
+        return ('', '')
+
+
+# TODO: find a better way to look up the branch in scope
+expected_codename, expected_major = get_osa_version(os.environ['RE_JOB_BRANCH'])
 
 
 @pytest.mark.test_id('2c596d8f-7957-11e8-8017-6a00035510c0')

--- a/molecule/default/tests/test_rpc_version.py
+++ b/molecule/default/tests/test_rpc_version.py
@@ -36,11 +36,13 @@ def test_openstack_release_version(host):
 
     # Expected example:
     # DISTRIB_RELEASE="r16.2.0"
+    print "expected_major: {}".format(expected_major)
     if expected_major.isdigit():
         pat = expected_major + r'.\d+.\d+'
     else:
         pat = r'\w+'
     expected_regex = re.compile('DISTRIB_RELEASE="r?{}"'.format(pat))
+    print "expected_regex: {}".format(expected_regex.pattern)
     release = host.file('/etc/openstack-release').content
     assert re.search(expected_regex, release)
 
@@ -57,7 +59,11 @@ def test_openstack_codename(host):
 
     # Expected example:
     # DISTRIB_CODENAME="Pike"
-    expected_regex = r'DISTRIB_CODENAME="' + expected_codename + r'"'
+    print "expected_codename: {}".format(expected_codename)
+    expected_regex = re.compile(r'DISTRIB_CODENAME="' +
+                                expected_codename +
+                                r'"')
+    print "expected_regex: {}".format(expected_regex.pattern)
     release = host.file('/etc/openstack-release').content
     assert re.search(expected_regex, release)
 
@@ -74,6 +80,12 @@ def test_rpc_version(host):
 
     # Expected example:
     # r13.1.0rc1-987-gbb6b806
-    expected_regex = r'[r]' + expected_major + r'.\d+.\d+'
+    print "expected_major: {}".format(expected_major)
+    if expected_major.isdigit():
+        pat = r'r?' + expected_major + r'.\d+.\d+'
+    else:
+        pat = r'r?' + r'.\d+' + r'.\d+.\d+'
+    expected_regex = re.compile(pat)
+    print "expected_regex: {}".format(expected_regex.pattern)
     res = host.run("cd /opt/rpc-openstack ; git describe --tags")
     assert re.search(expected_regex, res.stdout)


### PR DESCRIPTION
This commit implements a local version of the `get_osa_version` in order
to determine the expected version values to query for. The helper in
pytest-rpc currently derives these values based on the branch of the
repo in which the executed test resides. However, the molecule tests are
submodules of the rpc-openstack-system-tests repo when executed in CI.
This means that all of the molecule tests are in a detached HEAD state
and cannot determine the properly expected branch.

This implementation assumes that the environment variable for
RE_JOB_BRANCH has been set to the desired value. An exception will be
thrown if the this variable is unset.

The tests that utilize this functionality have been updated to use the
local method.