### PR TITLE
ASC-790 Support router-gateway for newton

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,17 @@
 ---
 # tasks file for molecule-rpc-openstack-post-deploy
+- name: Set the rpc-openstack variables
+  set_fact:
+    rpc_openstack: "{{ ansible_local['rpc_openstack']['rpc_product'] }}"
+
+- name: Set the rpc-release variable
+  set_fact:
+    rpc_product_release: "{{ rpc_openstack['rpc_product_release'] }}"
+  when:
+    - rpc_openstack['rpc_product_release'] is defined
+    - rpc_product_release is undefined or
+      rpc_product_release == 'undefined'
+
 - name: Install "openvswitch-switch" package
   apt:
      name: openvswitch-switch

--- a/tasks/network_setup.yml
+++ b/tasks/network_setup.yml
@@ -26,13 +26,23 @@
   changed_when: false
   failed_when: false
 
-- name: Unset gateway on test router
+- name: Unset gateway on test router (not newton)
   shell: |
     lxc-attach -n "{{ utility_container.stdout }}"  \
     -- bash -c '. /root/openrc ; \
     openstack router unset --external-gateway "{{ test_router }}"'
   when:
     - test_router_instance.rc == 0
+    - rpc_product_release != "newton"
+
+- name: Unset gateway on test router (newton)
+  shell: |
+    lxc-attach -n "{{ utility_container.stdout }}"  \
+    -- bash -c '. /root/openrc ; \
+    neutron router-gateway-clear "{{ test_router }}"'
+  when:
+    - test_router_instance.rc == 0
+    - rpc_product_release == "newton"
 
 - name: Remove test subnet from router
   shell: |
@@ -109,8 +119,18 @@
     -- bash -c '. /root/openrc ; \
     openstack router add subnet "{{ test_router }}" "{{ test_subnet }}"'
 
-- name: Set external gateway on router
+- name: Set external gateway on router (not newton)
   shell: |
     lxc-attach -n "{{ utility_container.stdout }}" \
     -- bash -c '. /root/openrc ; \
     openstack router set --external-gateway "{{ gateway_network }}" "{{ test_router }}"'
+  when:
+    - rpc_product_release != "newton"
+
+- name: Set external gateway on router (newton)
+  shell: |
+    lxc-attach -n "{{ utility_container.stdout }}" \
+    -- bash -c '. /root/openrc ; \
+    neutron router-gateway-set "{{ test_router }}" "{{ gateway_network }}"'
+  when:
+    - rpc_product_release == "newton"


### PR DESCRIPTION
This commit looks up the `rpc_product_release` fact. It provides
conditional logic to use the legacy `neutron router-gateway-[set|clear]`
when the product version is "newton", otherwise it will use the
`openstack router [set|unset] --external-gateway` command.