### PR TITLE
ASC-791 Use RPC_PRODUCT_RELEASE for version lookup

### DIFF
--- a/molecule/default/tests/test_dhcp_agents.py
+++ b/molecule/default/tests/test_dhcp_agents.py
@@ -30,7 +30,7 @@ def test_openvswitch(host):
     """
 
     expected_codename, expected_major = \
-        get_osa_version(os.environ['RE_JOB_BRANCH'])
+        get_osa_version(os.environ['RPC_PRODUCT_RELEASE'])
     print "expected_major: {}".format(expected_major)
     try:
         osa_major = int(expected_major)

--- a/molecule/default/tests/test_rpc_version.py
+++ b/molecule/default/tests/test_rpc_version.py
@@ -21,7 +21,8 @@ def get_osa_version(branch):
 
 
 # TODO: find a better way to look up the branch in scope
-expected_codename, expected_major = get_osa_version(os.environ['RE_JOB_BRANCH'])
+expected_codename, expected_major = \
+    get_osa_version(os.environ['RPC_PRODUCT_RELEASE'])
 
 
 @pytest.mark.test_id('2c596d8f-7957-11e8-8017-6a00035510c0')


### PR DESCRIPTION
This commit get the value of RPC_PRODUCT_RELEASE to be fed to the
get_osa_version helper to look up the expected values.