### PR TITLE
(ASC-855) openstack-service-setup.yml should not be executed twice in…

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,6 +16,7 @@
   apt:
      name: openvswitch-switch
 - import_tasks: os_service_setup.yml
+  when: openstack_service_setup_already_ran_successfully is not defined
 - import_tasks: support_key.yml
 - include_tasks: security_group_setup.yml
 - include_tasks: flavor_setup.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,7 +16,7 @@
   apt:
      name: openvswitch-switch
 - import_tasks: os_service_setup.yml
-  when: openstack_service_setup_already_ran_successfully is not defined
+  when: ansible_local.service_setup is not defined
 - import_tasks: support_key.yml
 - include_tasks: security_group_setup.yml
 - include_tasks: flavor_setup.yml

--- a/tasks/os_service_setup.yml
+++ b/tasks/os_service_setup.yml
@@ -45,6 +45,16 @@
     executable: /bin/bash
     chdir: /opt/openstack-ansible-ops/multi-node-aio-xenial-ansible/playbooks/
 
-- name: openstack-service-setup.yml was running successfully
-  set_fact:
-    openstack_service_setup_already_ran_successfully: true
+- name: create directory for ansible custome facts
+  file:
+    state: directory
+    recurse: yes
+    path: /etc/ansible/facts.d
+
+- name: install custom fact for service setup
+  copy:
+    content: "{\"already_ran\" : \"true\"}"
+    dest: /etc/ansible/facts.d/service_setup.fact
+
+- name: re-read facts after adding custome fact
+  setup: filter=ansible_local

--- a/tasks/os_service_setup.yml
+++ b/tasks/os_service_setup.yml
@@ -44,3 +44,7 @@
   args:
     executable: /bin/bash
     chdir: /opt/openstack-ansible-ops/multi-node-aio-xenial-ansible/playbooks/
+
+- name: openstack-service-setup.yml was running successfully
+  set_fact:
+    openstack_service_setup_already_ran_successfully: true


### PR DESCRIPTION
… system tests

System tests run openstack-service-setup.yml in each and every single molecule submodule, this duplication effort is unnecessary, slowing down test, and causing errors when idempotent is failing.

This PR adds condition check, if openstack-service-setup.yml has been run successfully once, it should not run again.