### PR TITLE
MAINT - Skip test_rpc_version for RI-410

### DIFF
--- a/molecule/default/tests/test_rpc_version.py
+++ b/molecule/default/tests/test_rpc_version.py
@@ -70,6 +70,7 @@ def test_openstack_codename(host):
 
 
 @pytest.mark.test_id('d7fc32ba-432a-11e8-81d4-6a00035510c0')
+@pytest.mark.skip(reason="RI-410")
 @pytest.mark.jira('ASC-234')
 def test_rpc_version(host):
     """Test to verify expected version of installed RPC-OpenStack


### PR DESCRIPTION
This `test_rpc_version` test fails and has been ticketed as RI-410. This
commit skips the test to allow the issue to be resolved without causing
CI runs to remain red.