### PR TITLE
MAINT - Fix rpc_version codename regex

### DIFF
--- a/molecule/default/tests/test_rpc_version.py
+++ b/molecule/default/tests/test_rpc_version.py
@@ -61,9 +61,11 @@ def test_openstack_codename(host):
     # Expected example:
     # DISTRIB_CODENAME="Pike"
     print "expected_codename: {}".format(expected_codename)
-    expected_regex = re.compile(r'DISTRIB_CODENAME="' +
-                                expected_codename +
-                                r'"')
+    if expected_codename:
+        pat = expected_codename
+    else:
+        pat = r'\w+'
+    expected_regex = re.compile('DISTRIB_CODENAME="{}"'.format(pat))
     print "expected_regex: {}".format(expected_regex.pattern)
     release = host.file('/etc/openstack-release').content
     assert re.search(expected_regex, release)


### PR DESCRIPTION
This commit updates the `test_openstack_codename` test to apply a
regular expression pattern matching any word character if the
`expected_codename` has not been set to a specific value.