### PR TITLE
ASC-790 rpc_product_release via ENV if fact unavai

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,14 +3,25 @@
 - name: Set the rpc-openstack variables
   set_fact:
     rpc_openstack: "{{ ansible_local['rpc_openstack']['rpc_product'] }}"
+  when:
+    - ansible_local.rpc_openstack is defined
+    - ansible_local.rpc_openstack.rpc_product is defined
 
 - name: Set the rpc-release variable
   set_fact:
     rpc_product_release: "{{ rpc_openstack['rpc_product_release'] }}"
   when:
+    - rpc_openstack is defined
     - rpc_openstack['rpc_product_release'] is defined
     - rpc_product_release is undefined or
       rpc_product_release == 'undefined'
+
+- name: Set the rpc-release variable from environment
+  set_fact:
+    rpc_product_release: "{{ lookup('env', 'RPC_PRODUCT_RELEASE') }}"
+  when:
+    - rpc_openstack is undefined or
+      rpc_openstack['rpc_product_release'] is undefined
 
 - name: Install "openvswitch-switch" package
   apt:

--- a/tasks/network_setup.yml
+++ b/tasks/network_setup.yml
@@ -34,6 +34,7 @@
   when:
     - test_router_instance.rc == 0
     - rpc_product_release != "newton"
+    - rpc_product_release != ""
 
 - name: Unset gateway on test router (newton)
   shell: |
@@ -42,7 +43,8 @@
     neutron router-gateway-clear "{{ test_router }}"'
   when:
     - test_router_instance.rc == 0
-    - rpc_product_release == "newton"
+    - rpc_product_release == "newton" or
+      rpc_product_release == ""
 
 - name: Remove test subnet from router
   shell: |
@@ -126,6 +128,7 @@
     openstack router set --external-gateway "{{ gateway_network }}" "{{ test_router }}"'
   when:
     - rpc_product_release != "newton"
+    - rpc_product_release != ""
 
 - name: Set external gateway on router (newton)
   shell: |
@@ -133,4 +136,5 @@
     -- bash -c '. /root/openrc ; \
     neutron router-gateway-set "{{ test_router }}" "{{ gateway_network }}"'
   when:
-    - rpc_product_release == "newton"
+    - rpc_product_release == "newton" or
+      rpc_product_release == ""


### PR DESCRIPTION
This PR updates the logic for setting the `rpc_product_release`
fact. If the fact is not available from a local fact file, then the
value is assumed to be set via the RPC_PRODUCT_RELEASE environment
variable.