### PR TITLE
(ASC-888) removed skipped tests which have been implemented in differ…

### DIFF
--- a/molecule/default/tests/test_for_acs-150.py
+++ b/molecule/default/tests/test_for_acs-150.py
@@ -12,82 +12,10 @@ class TestForRPC10PlusPostDeploymentQCProcess(object):
      https://rpc-openstack.atlassian.net/browse/ASC-150
      """
 
-    @pytest.mark.test_id('d7fc308a-432a-11e8-9b02-6a00035510c0')
-    @pytest.mark.skip(reason='Need implementation')
-    @pytest.mark.jira('ASC-150')
-    def test_reboot_physical_devices(self, host):
-        """See RPC 10+ Post-Deployment QC process document"""
-
-    @pytest.mark.test_id('d7fc3197-432a-11e8-829b-6a00035510c0')
-    @pytest.mark.skip(reason='Need implementation')
-    @pytest.mark.jira('ASC-150')
-    def test_verify_galera_cluster(self, host):
-        """See RPC 10+ Post-Deployment QC process document"""
-
     @pytest.mark.test_id('d7fc3423-432a-11e8-aaa8-6a00035510c0')
     @pytest.mark.skip(reason='Need implementation')
     @pytest.mark.jira('ASC-150')
     def test_verify_ceph_deploy(self, host):
-        """See RPC 10+ Post-Deployment QC process document"""
-
-    @pytest.mark.test_id('d7fc3507-432a-11e8-8667-6a00035510c0')
-    @pytest.mark.skip(reason='Need implementation')
-    @pytest.mark.jira('ASC-150')
-    def test_verify_configed_quotas(self, host):
-        """See RPC 10+ Post-Deployment QC process document"""
-
-    @pytest.mark.test_id('d7fc3621-432a-11e8-a95a-6a00035510c0')
-    @pytest.mark.skip(reason='Need implementation')
-    @pytest.mark.jira('ASC-150')
-    def test_verify_configed_networks(self, host):
-        """See RPC 10+ Post-Deployment QC process document"""
-
-    @pytest.mark.test_id('d7fc36f3-432a-11e8-87e9-6a00035510c0')
-    @pytest.mark.skip(reason='Need implementation')
-    @pytest.mark.jira('ASC-150')
-    def test_verify_updated_glance_image(self, host):
-        """See RPC 10+ Post-Deployment QC process document"""
-
-    @pytest.mark.test_id('d7fc380a-432a-11e8-9fc0-6a00035510c0')
-    @pytest.mark.skip(reason='Need implementation')
-    @pytest.mark.jira('ASC-150')
-    def test_build_instances_on_compute_node(self, host):
-        """See RPC 10+ Post-Deployment QC process document"""
-
-    @pytest.mark.test_id('d7fc38fa-432a-11e8-ae81-6a00035510c0')
-    @pytest.mark.skip(reason='Need implementation')
-    @pytest.mark.jira('ASC-150')
-    def test_verify_floating_ip_nats(self, host):
-        """See RPC 10+ Post-Deployment QC process document"""
-
-    @pytest.mark.test_id('d7fc39f5-432a-11e8-99b4-6a00035510c0')
-    @pytest.mark.skip(reason='Need implementation')
-    @pytest.mark.jira('ASC-150')
-    def test_verify_correct_number_rabbitmq_per_connection(self, host):
-        """See RPC 10+ Post-Deployment QC process document"""
-
-    @pytest.mark.test_id('d7fc3ab0-432a-11e8-ab7d-6a00035510c0')
-    @pytest.mark.skip(reason='Need implementation')
-    @pytest.mark.jira('ASC-150')
-    def test_create_cinder_volume(self, host):
-        """See RPC 10+ Post-Deployment QC process document"""
-
-    @pytest.mark.test_id('d7fc3bca-432a-11e8-8f27-6a00035510c0')
-    @pytest.mark.skip(reason='Need implementation')
-    @pytest.mark.jira('ASC-150')
-    def test_write_to_attached_volume_partition(self, host):
-        """See RPC 10+ Post-Deployment QC process document"""
-
-    @pytest.mark.test_id('d7fc3c87-432a-11e8-bfa2-6a00035510c0')
-    @pytest.mark.skip(reason='Need implementation')
-    @pytest.mark.jira('ASC-150')
-    def test_create_volume_on_image_on_glance(self, host):
-        """See RPC 10+ Post-Deployment QC process document"""
-
-    @pytest.mark.test_id('d7fc3d80-432a-11e8-a735-6a00035510c0')
-    @pytest.mark.skip(reason='Need implementation')
-    @pytest.mark.jira('ASC-150')
-    def test_create_snapshot_of_an_instance(self, host):
         """See RPC 10+ Post-Deployment QC process document"""
 
     @pytest.mark.test_id('d7fc3f4c-432a-11e8-bf4f-6a00035510c0')


### PR DESCRIPTION
…ent molecules

This PR to removes:
1. test_reboot_physical_devices: since it has been implemented here in nova:
- Reboot nova and logging hosts: https://github.com/rcbops/molecule-validate-nova-deploy/commit/6e328be3e1f4b8b5a9737244d0ad7c454eeb4285
- Reboot all infra hosts: https://github.com/rcbops/molecule-validate-nova-deploy/pull/26/commits/6a313c86c0a671e9b1eb7d717dc9b6a51993f4b3
- Reboot all cinder hosts: https://github.com/rcbops/molecule-validate-nova-deploy/pull/26/commits/6a313c86c0a671e9b1eb7d717dc9b6a51993f4b3

2. test_verify_galera_cluster: since it has been implemented here in nova:
https://github.com/rcbops/molecule-validate-nova-deploy/commit/f80159deb55deb97f3b5b81a82f629a2f4b2e8ad

3. test_verify_configed_quotas: since it has been implemented here in nova:
https://github.com/rcbops/molecule-validate-nova-deploy/blob/master/molecule/default/tests/test_verify_configured_quotas.py

4. test_verify_configed_networks: since it has been implemented in neutron:
https://github.com/rcbops/molecule-validate-neutron-deploy/blob/master/molecule/default/tests/test_verify_networks_created.py

5. test_verify_updated_glance_image: since it has been implemented in glance:
https://github.com/rcbops/molecule-validate-glance-deploy/blob/master/molecule/default/tests/test_scan_images_and_flavors.py

6. test_build_instances_on_compute_node: since it has been implemented here in cinder:
https://github.com/rcbops/molecule-validate-cinder-deploy/blob/master/molecule/default/tests/test_create_instance_from_bootable_volume.py

7. test_verify_floating_ip_nats: since it has been implemented here in nova:
https://github.com/rcbops/molecule-validate-nova-deploy/blob/master/molecule/default/tests/test_create_and_assign_floating_ip.py

8. test_verify_correct_number_rabbitmq_per_connection: since it has been implemented here in nova:
https://github.com/rcbops/molecule-validate-nova-deploy/blob/master/molecule/default/tests/test_verify_one_rabbitmp_channel_per_connection.py

9. test_create_cinder_volume: since it has been implemented here in cinder:
https://github.com/rcbops/molecule-validate-cinder-deploy/blob/master/molecule/default/tests/test_cinder_volume.py

10. test_write_to_attached_volume_partition: since it has been implemented here in post deploy:
https://github.com/rcbops/molecule-rpc-openstack-post-deploy/blob/master/molecule/default/tests/test_write_to_attached_storage.py

11. test_create_volume_on_image_on_glance: since it has been implemented here in cinder:
https://github.com/rcbops/molecule-validate-cinder-deploy/blob/master/molecule/default/tests/test_create_bootable_volume.py

12. test_create_snapshot_of_an_instance: since it has been implemented here in nova:
https://github.com/rcbops/molecule-validate-nova-deploy/blob/master/molecule/default/tests/test_create_snapshot_on_instance.py