### PR TITLE
(ASC-896) use available pip from the host

### DIFF
--- a/tasks/os_service_setup.yml
+++ b/tasks/os_service_setup.yml
@@ -13,13 +13,13 @@
     dest=/opt/openstack-ansible-ops
 
 - name: Create python2 virtualenv for the submodule
-  shell: virtualenv --no-pip --no-setuptools --no-wheel --no-download --no-site-packages /opt/molecule-test-env-on-sut
+  shell: virtualenv --no-download --no-site-packages /opt/molecule-test-env-on-sut
   when:
     - rpc_product_release != "master" or
       rpc_product_release != "rocky"
 
 - name: Create python3 virtualenv for the submodule
-  shell: virtualenv --no-pip --no-setuptools --no-wheel --no-download --no-site-packages --python=python3 /opt/molecule-test-env-on-sut
+  shell: virtualenv --no-download --no-site-packages --python=python3 /opt/molecule-test-env-on-sut
   when:
     - rpc_product_release == "master" or
       rpc_product_release == "rocky"


### PR DESCRIPTION
Previous commit (131621ccc2d73d3c230914b489dff58b219bd343) has helped to create virtualenv on SUT, however, it didn't install pip which is need the the next ansible task in os_service_setup.yml.
This PR will try to use the available pip on the host.