### PR TITLE
(ASC-922) cloning rpc-maas repo

### DIFF
--- a/tasks/maas_setup.yml
+++ b/tasks/maas_setup.yml
@@ -7,6 +7,16 @@
     group: "root"
     mode: "0600"
 
+- name: Clean old rpc-maas dir if previously existing
+  file:
+    state: absent
+    path: /opt/rpc-maas
+
+- name: Clone rpc-maas repo
+  git:
+    repo=https://github.com/rcbops/rpc-maas.git
+    dest=/opt/rpc-maas
+
 - name: Set the rpc_maas vars
   shell: |
     cd /opt/rpc-maas/playbooks


### PR DESCRIPTION
Prior to this PR, rpc-maas repo is not cloned during RCP-O deployment.
This PR is to clone the repo for rpc-maas test.