### PR TITLE
(ASC-922) set maas_pre_flight_metadata_check_enabled to false

### DIFF
--- a/tasks/maas_setup.yml
+++ b/tasks/maas_setup.yml
@@ -21,6 +21,6 @@
   shell: |
     cd /opt/rpc-maas/playbooks
     sed -i 's|^# influx_telegraf_targets|influx_telegraf_targets|g' /etc/openstack_deploy/user_rpco_maas_variables.yml
-    openstack-ansible site.yml
+    openstack-ansible -e maas_pre_flight_metadata_check_enabled=false site.yml
   changed_when: false
   failed_when: false


### PR DESCRIPTION
Prior to this PR, ansible tasks failed at task "Check metadata variables are defined" in https://github.com/rcbops/rpc-maas/blob/master/playbooks/maas-pre-flight.yml because `rpc_env_identifier` is set to be `unknown` in https://github.com/rcbops/rpc-maas/blob/master/playbooks/templates/common/macros.jinja

This PR is to skip the mass_pre_flight_metadata by setting maas_pre_flight_metadata_check_enabled to be false.