### PR TITLE
(ASC-922) set maas_rabbitmq_password for maas setup

### DIFF
--- a/tasks/maas_setup.yml
+++ b/tasks/maas_setup.yml
@@ -19,6 +19,8 @@
 
 - name: Set the rpc_maas vars
   shell: |
+    echo 'maas_rabbitmq_password: secrete' | tee -a /etc/openstack_deploy/user_secrets.yml
+    cat /etc/openstack_deploy/user_secrets.yml
     cd /opt/rpc-maas/playbooks
     sed -i 's|^# influx_telegraf_targets|influx_telegraf_targets|g' /etc/openstack_deploy/user_rpco_maas_variables.yml
     openstack-ansible -e maas_pre_flight_metadata_check_enabled=false site.yml


### PR DESCRIPTION
Prior to this PR, maas_rabbitmq_password variable is not defined on CI, so it fails to run the maas-infra-rabbitmq.yml playbook that creates a user within the rabbitmq cluster for the purposes of monitoring.

This PR is to set the maas_rabbitmp_password to be a default value as defined in https://github.com/rcbops/rpc-maas/blob/7e1bde1df338cb60fcfd810b43ed3c8640670311/doc/source/usage.rst