### PR TITLE
(ASC-997) Added rpc-maas credentials into user_secrets.yml

### DIFF
--- a/tasks/maas_setup.yml
+++ b/tasks/maas_setup.yml
@@ -17,9 +17,17 @@
     repo=https://github.com/rcbops/rpc-maas.git
     dest=/opt/rpc-maas
 
-- name: Maas setup
+- name: Maas credentials setup
   shell: |
-    cat /opt/rpc-maas/tests/user_rpcm_secrets.yml >> /etc/openstack_deploy/user_secrets.yml
+    echo 'maas_rabbitmq_password: secrete' | tee -a /etc/openstack_deploy/user_secrets.yml
+    echo 'maas_keystone_password: secrete' | tee -a /etc/openstack_deploy/user_secrets.yml
+    echo 'maas_rally_users_password: secrete' | tee -a /etc/openstack_deploy/user_secrets.yml
+    echo 'maas_rally_galera_password: secrete' | tee -a /etc/openstack_deploy/user_secrets.yml
+    echo 'maas_swift_accesscheck_password: secrete' | tee -a /etc/openstack_deploy/user_secrets.yml
+    echo 'influxdb_db_root_password: secrete' | tee -a /etc/openstack_deploy/user_secrets.yml
+    echo 'influxdb_db_metric_password: secrete' | tee -a /etc/openstack_deploy/user_secrets.yml
+    echo 'grafana_db_password: secrete' | tee -a /etc/openstack_deploy/user_secrets.yml
+    echo 'grafana_admin_password: secrete' | tee -a /etc/openstack_deploy/user_secrets.yml
 
 - name: Set the rpc_maas vars
   shell: |


### PR DESCRIPTION
This is a dirty way to add rpc-maas credentials into user_secrets.yml file to see if deploying mass with these credentials would work. If not, then /opt/openstack-ansible/scripts/pw-token-gen.py before deploying RCP-O must be considered.