### PR TITLE
(ASC-922) concat rpc-maas rpcm secret file to rpco user_secrets yml file

### DIFF
--- a/tasks/maas_setup.yml
+++ b/tasks/maas_setup.yml
@@ -18,16 +18,7 @@
     dest=/opt/rpc-maas
 
 - name: Maas credentials setup
-  shell: |
-    echo 'maas_rabbitmq_password: secrete' | tee -a /etc/openstack_deploy/user_secrets.yml
-    echo 'maas_keystone_password: secrete' | tee -a /etc/openstack_deploy/user_secrets.yml
-    echo 'maas_rally_users_password: secrete' | tee -a /etc/openstack_deploy/user_secrets.yml
-    echo 'maas_rally_galera_password: secrete' | tee -a /etc/openstack_deploy/user_secrets.yml
-    echo 'maas_swift_accesscheck_password: secrete' | tee -a /etc/openstack_deploy/user_secrets.yml
-    echo 'influxdb_db_root_password: secrete' | tee -a /etc/openstack_deploy/user_secrets.yml
-    echo 'influxdb_db_metric_password: secrete' | tee -a /etc/openstack_deploy/user_secrets.yml
-    echo 'grafana_db_password: secrete' | tee -a /etc/openstack_deploy/user_secrets.yml
-    echo 'grafana_admin_password: secrete' | tee -a /etc/openstack_deploy/user_secrets.yml
+  shell: sed -e '/^\(#\|-\|$\)/d' /opt/rpc-maas/tests/user_rpcm_secrets.yml >> /etc/openstack_deploy/user_secrets.yml
 
 - name: Set the rpc_maas vars
   shell: |


### PR DESCRIPTION
The credentials in rpc-maas/tests/user_rpcm_secrets.yml file is needed while executing maas site.yml playbook.

Cconcatnating the first yml file onto the second yml file creates some format errors when executing site.yml ansible playbook.
This PR is to remove the lines starting with '---', '#', or an empty line of the rpc-maas user_rpcm_secrets.yml before adding the credentials to user_secrets.yml