### PR TITLE
ASC-1035 Ensure authorized key on containers

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,6 +26,7 @@
 - name: Install "openvswitch-switch" package
   apt:
      name: openvswitch-switch
+- import_tasks: ssh_key_containers.yml
 - import_tasks: os_service_setup.yml
   when: ansible_local.service_setup is not defined
 - import_tasks: support_key.yml

--- a/tasks/ssh_key_containers.yml
+++ b/tasks/ssh_key_containers.yml
@@ -1,0 +1,9 @@
+---
+- name: Get all containers
+  shell: |
+    lxc-ls -1
+  register: containers
+- name: Add authorized key on containers
+  shell: |
+    lxc-attach -n "{{ item }}" -- bash -c 'echo "{{ public_key }}" >> /root/.ssh/authorized_keys'
+  with_items: "{{ containers.stdout_lines }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,5 +1,6 @@
 ---
 # vars file for molecule-rpc-openstack-post-deploy
+public_key: "{{ lookup('file', '/root/.ssh/id_rsa.pub') }}"
 ops_apt_util_packages:
   - bash-completion
   - bridge-utils


### PR DESCRIPTION
This commit adds a task to ensure that the ssh key for root on localhost
is added to the infrastructure containers. Prior to this commit, running
the molecule converge step failed when the MNAIO environment was
deployed from pre-existing images. This is because the deploy hosts key
is propagated to the VMs in the environment but not the containers.