### PR TITLE
(RI-471) added more server status checks and increase time search for…

### DIFF
--- a/molecule/default/tests/test_instance_per_network_per_hypervisor.py
+++ b/molecule/default/tests/test_instance_per_network_per_hypervisor.py
@@ -108,7 +108,11 @@ def test_hypervisor_vms(host):
                                           network['id'], compute['Zone'],
                                           instance_name)
                 assert helpers.get_expected_value('server', server['id'],
+                                                  'OS-EXT-STS:power_state', 'Running', host, 15)
+                assert helpers.get_expected_value('server', server['id'],
                                                   'status', 'ACTIVE', host, 15)
+                assert helpers.get_expected_value('server', server['id'],
+                                                  'OS-EXT-STS:vm_state', 'active', host, 15)
                 server_list.append(server['id'])
 
     for server in server_list:
@@ -129,7 +133,7 @@ def test_hypervisor_vms(host):
         # confirm SSH port access
         cmd = "{} 'ip netns exec \
                qdhcp-{} nc -w1 {} 22'".format(na_pre, network['id'], ip)
-        for attempt in range(10):
+        for attempt in range(30):
             res = host.run(cmd)
             try:
                 assert 'SSH' in res.stdout


### PR DESCRIPTION
… SSH

Prior to this PR, port 22 on newly created server cannot be reached using automated test, but it can be when doing it manually, it is possible that automated test run too fast that the newly created server ssh is not ready.

This PR is to increase the trial time from 100 seconds to 5 minutes, also add two more status checks on the newly created server: "OS-EXT-STS:power_state" and "OS-EXT-STS:vm_state" to ensure the server is ready before proceeding to SSH verification.