### PR TITLE
RI-417 Remove xfail tags

### DIFF
--- a/molecule/default/tests/test_instance_per_network_per_hypervisor.py
+++ b/molecule/default/tests/test_instance_per_network_per_hypervisor.py
@@ -34,7 +34,6 @@ def create_server_on(target_host, image_id, flavor, network_id, compute_zone, se
 
 @pytest.mark.test_id('c3002bde-59f1-11e8-be3b-6c96cfdb252f')
 @pytest.mark.jira('ASC-241', 'ASC-883', 'ASC-789', 'RI-417')
-@pytest.mark.xfail(strict=True)  # The test will be recorded as failed if unexpected XPASS when 'RI-417' is fixed
 def test_hypervisor_vms(host):
     """ASC-241: Per network, spin up an instance on each hypervisor, perform
     external ping, and tear-down """

--- a/molecule/default/tests/test_write_to_attached_storage.py
+++ b/molecule/default/tests/test_write_to_attached_storage.py
@@ -63,7 +63,6 @@ def attach_volume_to_server(volume, server, run_on_host):
 
 @pytest.mark.test_id('3d77bc35-7a21-11e8-90d1-6a00035510c0')
 @pytest.mark.jira('ASC-257', 'ASC-883', 'RI-417')
-@pytest.mark.xfail(strict=True)  # The test will be recorded as failed if unexpected XPASS when 'RI-417' is fixed
 def test_volume_attached(host):
     vars = host.ansible('include_vars',
                         'file=./vars/main.yml')['ansible_facts']


### PR DESCRIPTION
The two tests that were previously failing due the lack of being able to
SSH into the SUT have triggered failures via the xfail tag. This means
that the tests unexpectedly passed indicating that the issue has been
resolved. This commit removes these tags so that the tests will resume
there normal behavior.