### PR TITLE
 ASC-1044 Add delete networks task

### DIFF
--- a/tasks/delete_existing_networks.yml
+++ b/tasks/delete_existing_networks.yml
@@ -1,0 +1,102 @@
+---
+# openstack router unset --external-gateway  TEST-ROUTER
+# ^^^ allows gateway subnet to be deleted
+
+# Get router list
+# For each router
+#   openstack router unset --external-gateway router
+#   openstack router remove subnet router <subnet0>...<subnetn>
+#   openstack router delete router
+# Get subnet list
+# For each subnet
+#   openstack subnet delete subnet
+# Get network list
+# For each network
+#   openstack network delete network
+
+####################  Begin Remove Routers  #####################
+- name: Get router list
+  shell: |
+    lxc-attach -n "{{ utility_container.stdout }}"  \
+    -- bash -c '. /root/openrc ; \
+    openstack router list -f value -c ID'
+  register: output
+
+- name: Set router list fact
+  set_fact:
+    router_list_output: "{{ output.stdout_lines }}"
+
+- name: Unset external-gateway on router
+  shell: |
+    lxc-attach -n "{{ utility_container.stdout }}"  \
+    -- bash -c '. /root/openrc ; \
+    openstack router unset --external-gateway "{{ item }}"'
+  with_items: "{{ router_list_output }}"
+
+- name: Get router details
+  shell: |
+    lxc-attach -n "{{ utility_container.stdout }}"  \
+    -- bash -c '. /root/openrc ; \
+    openstack router show -f json "{{ item }}"'
+  register: output
+  with_items: "{{ router_list_output }}"
+
+- name: Set router details fact
+  set_fact:
+    router_details_output: "{{ output.results }}"
+
+- name: Remove subnets from routers
+  shell: |
+    lxc-attach -n "{{ utility_container.stdout }}"  \
+    -- bash -c '. /root/openrc ; \
+    openstack router remove subnet {{ (item.stdout | from_json).id }} {{ (item.stdout | from_json).interfaces_info | from_json | json_query("[*].subnet_id") | join(" ") }}'
+  when:  '(item.stdout | from_json).interfaces_info | from_json | json_query("[*].subnet_id") | join(" ")'
+  with_items: "{{ router_details_output }}"
+
+- name: Delete router
+  shell: |
+    lxc-attach -n "{{ utility_container.stdout }}"  \
+    -- bash -c '. /root/openrc ; \
+    openstack router delete "{{ item }}"'
+  with_list: "{{ router_list_output }}"
+####################  End Remove Routers    #####################
+
+####################  Begin Remove Subnets  #####################
+- name: Get subnets
+  shell: |
+    lxc-attach -n "{{ utility_container.stdout }}"  \
+    -- bash -c '. /root/openrc ; \
+    openstack subnet list -f value -c ID'
+  register: output
+
+- name: Set subnet list fact
+  set_fact:
+    subnet_list_output: "{{ output.stdout_lines }}"
+
+- name: Delete subnets
+  shell: |
+    lxc-attach -n "{{ utility_container.stdout }}"  \
+    -- bash -c '. /root/openrc ; \
+    openstack subnet delete "{{ item }}"'
+  with_items: "{{ subnet_list_output }}"
+####################  End Remove Subnets    #####################
+
+####################  Begin Remove Networks #####################
+- name: Get networks
+  shell: |
+    lxc-attach -n "{{ utility_container.stdout }}"  \
+    -- bash -c '. /root/openrc ; \
+    openstack network list -f value -c ID'
+  register: output
+
+- name: Set network list fact
+  set_fact:
+    network_list_output: "{{ output.stdout_lines }}"
+
+- name: Delete networks
+  shell: |
+    lxc-attach -n "{{ utility_container.stdout }}"  \
+    -- bash -c '. /root/openrc ; \
+    openstack network delete "{{ item }}"'
+  with_items: "{{ network_list_output }}"
+####################  End Remove Networks   #####################

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,28 +1,6 @@
 ---
 # tasks file for molecule-rpc-openstack-post-deploy
-- name: Set the rpc-openstack variables
-  set_fact:
-    rpc_openstack: "{{ ansible_local['rpc_openstack']['rpc_product'] }}"
-  when:
-    - ansible_local.rpc_openstack is defined
-    - ansible_local.rpc_openstack.rpc_product is defined
-
-- name: Set the rpc-release variable
-  set_fact:
-    rpc_product_release: "{{ rpc_openstack['rpc_product_release'] }}"
-  when:
-    - rpc_openstack is defined
-    - rpc_openstack['rpc_product_release'] is defined
-    - rpc_product_release is undefined or
-      rpc_product_release == 'undefined'
-
-- name: Set the rpc-release variable from environment
-  set_fact:
-    rpc_product_release: "{{ lookup('env', 'RPC_PRODUCT_RELEASE') }}"
-  when:
-    - rpc_openstack is undefined or
-      rpc_openstack['rpc_product_release'] is undefined
-
+- import_tasks: set_facts.yml
 - name: Install "openvswitch-switch" package
   apt:
      name: openvswitch-switch

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,8 @@
   apt:
      name: openvswitch-switch
 - import_tasks: ssh_key_containers.yml
+- import_tasks: delete_existing_networks.yml
+  when: ansible_local.service_setup is not defined
 - import_tasks: os_service_setup.yml
   when: ansible_local.service_setup is not defined
 - import_tasks: support_key.yml

--- a/tasks/os_service_setup.yml
+++ b/tasks/os_service_setup.yml
@@ -50,15 +50,6 @@
     - ipaddr==2.2.0
     - netaddr==0.7.19
 
-- name: Find the proper inventory file
-  shell: find /opt/openstack-ansible -name dynamic_inventory.py -print
-  register: find_inventory_file
-  ignore_errors: true
-
-- name: Set proper inventory file
-  set_fact:
-    inventory_file: "{{ find_inventory_file.stdout }}"
-
 - name: Run openstack-service-setup
   shell: |
     . /opt/molecule-test-env-on-sut/bin/activate

--- a/tasks/set_facts.yml
+++ b/tasks/set_facts.yml
@@ -1,0 +1,38 @@
+---
+- name: Set the rpc-openstack variables
+  set_fact:
+    rpc_openstack: "{{ ansible_local['rpc_openstack']['rpc_product'] }}"
+  when:
+    - ansible_local.rpc_openstack is defined
+    - ansible_local.rpc_openstack.rpc_product is defined
+
+- name: Set the rpc-release variable
+  set_fact:
+    rpc_product_release: "{{ rpc_openstack['rpc_product_release'] }}"
+  when:
+    - rpc_openstack is defined
+    - rpc_openstack['rpc_product_release'] is defined
+    - rpc_product_release is undefined or
+      rpc_product_release == 'undefined'
+
+- name: Set the rpc-release variable from environment
+  set_fact:
+    rpc_product_release: "{{ lookup('env', 'RPC_PRODUCT_RELEASE') }}"
+  when:
+    - rpc_openstack is undefined or
+      rpc_openstack['rpc_product_release'] is undefined
+
+- name: Find the proper inventory file
+  shell: find /opt/openstack-ansible -name dynamic_inventory.py -print
+  register: find_inventory_file
+  ignore_errors: true
+
+- name: Set proper inventory file
+  set_fact:
+    inventory_file: "{{ find_inventory_file.stdout }}"
+
+- name: Register utility container
+  shell: |
+    lxc-ls -1 | grep utility | head -n 1
+  register: utility_container
+

--- a/tasks/support_key.yml
+++ b/tasks/support_key.yml
@@ -1,9 +1,4 @@
 ---
-- name: Register utility container
-  shell: |
-    lxc-ls -1 | grep utility | head -n 1
-  register: utility_container
-
 - name: Install packages required for RPC support
   apt:
     pkg: "{{ item }}"


### PR DESCRIPTION
When testing on MNAIO images previously deployed, there can be existing
openstack network resources that prevent the openstack-service-setup
from being able to deploy its expected network topology.

This commit adds a set of tasks to delete any existing openstack network
resources prior to executing the openstack-service-setup.