### PR TITLE
(ASC-897) (ASC-898) (ASC-899) Run maas-verify.yml --tags "maas-verify…

### DIFF
--- a/tasks/maas_setup.yml
+++ b/tasks/maas_setup.yml
@@ -28,5 +28,12 @@
   changed_when: false
   failed_when: false
 
+- name: Run maas-verify-local
+  shell: |
+    cd /opt/rpc-maas/playbooks
+    openstack-ansible maas-verify.yml --tags "maas-verify-local" -vvv
+  changed_when: false
+  failed_when: false
+
 - name: Debug Maas playbook content
   shell: tail -n +1 /etc/openstack_deploy/*.yml


### PR DESCRIPTION
…-local"

rpc-maas repo has a playbook named maas-verify.yml that validates the maas after running openstack-ansible site.yml to install and config maas on RCP-O, the playbook verifies many checks for maas.

For this PR, we are going to verify only one task: "Run MaaS verify local" in the maas-verify.yml playbook.