### PR TITLE
ASC-1049 Add delete security groups task

### DIFF
--- a/tasks/delete_existing_security_groups.yml
+++ b/tasks/delete_existing_security_groups.yml
@@ -1,0 +1,14 @@
+---
+- name: Get security group list
+  shell: |
+    lxc-attach -n "{{ utility_container.stdout }}"  \
+    -- bash -c '. /root/openrc ; \
+    openstack security group list -f value -c ID'
+  register: output
+
+- name: Delete security groups
+  shell: |
+    lxc-attach -n "{{ utility_container.stdout }}"  \
+    -- bash -c '. /root/openrc ; \
+    openstack security group delete "{{ item }}"'
+  with_items: "{{ output.stdout_lines }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,8 @@
 - import_tasks: ssh_key_containers.yml
 - import_tasks: delete_existing_networks.yml
   when: ansible_local.service_setup is not defined
+- import_tasks: delete_existing_security_groups.yml
+  when: ansible_local.service_setup is not defined
 - import_tasks: os_service_setup.yml
   when: ansible_local.service_setup is not defined
 - import_tasks: support_key.yml


### PR DESCRIPTION
When testing on MNAIO images previously deployed, there can be existing
openstack security group resources that prevent the
openstack-service-setup from being able to deploy its expected security
groups. This failure also prevents the playbook advancing to the image
creation task.

This commit adds a set of tasks to delete any existing openstack
security group resources prior to executing the openstack-service-setup.