### PR TITLE
(ASC-901) Added async to fix the timout issue

### DIFF
--- a/tasks/maas_setup.yml
+++ b/tasks/maas_setup.yml
@@ -24,9 +24,18 @@
   shell: |
     cd /opt/rpc-maas/playbooks
     sed -i 's|^# influx_telegraf_targets|influx_telegraf_targets|g' /etc/openstack_deploy/user_rpco_maas_variables.yml
-    openstack-ansible -e maas_pre_flight_metadata_check_enabled=false site.yml
+    openstack-ansible -e maas_pre_flight_metadata_check_enabled=false site.yml -vvv
+  async: 1200
+  poll: 5
   changed_when: false
   failed_when: false
 
-- name: Debug Maas playbook content
-  shell: tail -n +1 /etc/openstack_deploy/*.yml
+- name: Run maas-verify-local
+  shell: |
+    cd /opt/rpc-maas/playbooks
+    openstack-ansible maas-verify.yml --tags "maas-verify-local" -vvv
+  async: 1800
+  poll: 5
+  changed_when: false
+  failed_when: false
+  register: run_maas_verify_local


### PR DESCRIPTION
Prior to this PR, ansible task of 'Run maas-verify-local' in maas-setup.yml is running too long and went over the ssh timeout.
This PR to add async to the task to fix the timeout issue