### PR TITLE
ASC-1053 Skip maas setup on newton

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,3 +19,4 @@
 - import_tasks: server_setup.yml
 - import_tasks: volume_setup.yml
 - import_tasks: maas_setup.yml
+  when: rpc_product_release != 'newton'


### PR DESCRIPTION
Currently, the maas setup assumes that the maas variables file is
located at
`/opt/rpc-openstack/etc/openstack_deploy/user_rpco_maas_variables.yml`
which is not the case on newton. This commit sets the inclusion of the
maas setup playbook to be skipped on newton.