### PR TITLE
Revert "(Maint) remove maas setup and verify from production"

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,4 +18,5 @@
 - import_tasks: network_setup.yml
 - import_tasks: server_setup.yml
 - import_tasks: volume_setup.yml
-# - import_tasks: maas_setup.yml
+- import_tasks: maas_setup.yml
+  when: rpc_product_release != 'newton'


### PR DESCRIPTION
Reverts rcbops/molecule-rpc-openstack-post-deploy#96 to get maas setup and verify tasks back to 'dev' branch