### PR TITLE
ASC-1053 Create custom fact - rpc_product_release

### DIFF
--- a/molecule/default/tests/test_dhcp_agents.py
+++ b/molecule/default/tests/test_dhcp_agents.py
@@ -17,7 +17,7 @@ def test_openvswitch(host):
     Ensure DHCP agents for all networks are up
     """
 
-    r = host.ansible("setup")["ansible_facts"]["ansible_local"]["rpc_openstack"]["rpc_product"]["rpc_product_release"]
+    r = host.ansible("setup")["ansible_facts"]["ansible_local"]["system_tests"]["rpc_product_release"]
     expected_codename, expected_major = helpers.get_osa_version(r)
     print "expected_major: {}".format(expected_major)
     try:

--- a/molecule/default/tests/test_rpc_version.py
+++ b/molecule/default/tests/test_rpc_version.py
@@ -18,7 +18,7 @@ def test_openstack_release_version(host):
         testinfra_hosts
     """
 
-    r = host.ansible("setup")["ansible_facts"]["ansible_local"]["rpc_openstack"]["rpc_product"]["rpc_product_release"]
+    r = host.ansible("setup")["ansible_facts"]["ansible_local"]["system_tests"]["rpc_product_release"]
     expected_codename, expected_major = helpers.get_osa_version(r)
 
     # Expected example:
@@ -44,7 +44,7 @@ def test_openstack_codename(host):
         testinfra_hosts
     """
 
-    r = host.ansible("setup")["ansible_facts"]["ansible_local"]["rpc_openstack"]["rpc_product"]["rpc_product_release"]
+    r = host.ansible("setup")["ansible_facts"]["ansible_local"]["system_tests"]["rpc_product_release"]
     expected_codename, expected_major = helpers.get_osa_version(r)
 
     # Expected example:

--- a/molecule/default/tests/test_swift_stat.py
+++ b/molecule/default/tests/test_swift_stat.py
@@ -17,7 +17,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 def test_verify_swift_stat(host):
     """Verify the swift endpoint status."""
 
-    r = host.ansible("setup")["ansible_facts"]["ansible_local"]["rpc_openstack"]["rpc_product"]["rpc_product_release"]
+    r = host.ansible("setup")["ansible_facts"]["ansible_local"]["system_tests"]["rpc_product_release"]
     codename, major = helpers.get_osa_version(r)
 
     if not major.isdigit() or major > 17:

--- a/tasks/set_facts.yml
+++ b/tasks/set_facts.yml
@@ -1,4 +1,29 @@
 ---
+- name: Ensure path for ansible custom facts
+  file:
+    state: directory
+    recurse: yes
+    path: "{{ custom_fact_path }}"
+
+- name: Ensure file for ansible custom facts
+  file:
+    state: touch
+    path: "{{ custom_fact_path }}/system_tests.fact"
+
+- name: Create beginning of custom fact file
+  lineinfile:
+    state: present
+    insertbefore: BOF
+    line: "{"
+    path: "{{ custom_fact_path }}/system_tests.fact"
+
+- name: Create end of custom fact file
+  lineinfile:
+    state: present
+    insertbefore: EOF
+    line: "}"
+    path: "{{ custom_fact_path }}/system_tests.fact"
+
 - name: Set the rpc-openstack variables
   set_fact:
     rpc_openstack: "{{ ansible_local['rpc_openstack']['rpc_product'] }}"
@@ -21,6 +46,13 @@
   when:
     - rpc_openstack is undefined or
       rpc_openstack['rpc_product_release'] is undefined
+
+- name: Create custom fact for rpc_product_release
+  lineinfile:
+    state: present
+    insertbefore: '^}$'
+    line: '"rpc_product_release" : "{{ rpc_product_release }}"'
+    path: "{{ custom_fact_path }}/system_tests.fact"
 
 - name: Find the proper inventory file
   shell: find /opt/openstack-ansible -name dynamic_inventory.py -print

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -32,3 +32,4 @@ test_router: TEST-ROUTER
 test_network: TEST-VXLAN
 test_subnet: TEST-VXLAN-SUBNET
 gateway_network: GATEWAY_NET
+custom_fact_path: /etc/ansible/facts.d


### PR DESCRIPTION
This commit creates a custom ansible fact to store the result of the
query of the rpc_product_release value regardless of whether that comes
from a deployed OSA custom fact or via an environment variable. This
custom fact is then available to the tests after the converge step has
concluded. The fact exists in the following hierarchy:

["ansible_facts"]["ansible_local"]["system_tests"]["rpc_product_release"]