### PR TITLE
ASC-1100 Use shared-infra_hosts

### DIFF
--- a/molecule/default/tests/test_dhcp_agents.py
+++ b/molecule/default/tests/test_dhcp_agents.py
@@ -7,7 +7,7 @@ import pytest_rpc.helpers as helpers
 """ASC-157: Perform Post Deploy System validations"""
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('os-infra_hosts')[:1]
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('shared-infra_hosts')[:1]
 
 
 @pytest.mark.test_id('d7fc25ae-432a-11e8-a20a-6a00035510c0')

--- a/molecule/default/tests/test_env_scan.py
+++ b/molecule/default/tests/test_env_scan.py
@@ -6,7 +6,7 @@ import json
 """ASC-157: Perform Post Deploy System validations"""
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('os-infra_hosts')[:1]
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('shared-infra_hosts')[:1]
 
 os_pre = ("lxc-attach -n $(lxc-ls -1 | grep utility | head -n 1) "
           "-- bash -c '. /root/openrc ; openstack ")

--- a/molecule/default/tests/test_instance_per_network_per_hypervisor.py
+++ b/molecule/default/tests/test_instance_per_network_per_hypervisor.py
@@ -10,7 +10,7 @@ from time import sleep
 external ping, and tear-down """
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('os-infra_hosts')[:1]
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('shared-infra_hosts')[:1]
 
 os_pre = ("lxc-attach -n $(lxc-ls -1 | grep utility | head -n 1) "
           "-- bash -c '. /root/openrc ; openstack ")

--- a/molecule/default/tests/test_rpc_version.py
+++ b/molecule/default/tests/test_rpc_version.py
@@ -5,7 +5,7 @@ import re
 import pytest_rpc.helpers as helpers
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('os-infra_hosts')[:1]
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('shared-infra_hosts')[:1]
 
 
 @pytest.mark.test_id('2c596d8f-7957-11e8-8017-6a00035510c0')

--- a/molecule/default/tests/test_swift_dispersion.py
+++ b/molecule/default/tests/test_swift_dispersion.py
@@ -10,7 +10,7 @@ See RPC 10+ Post-Deployment QC process document
 """
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('os-infra_hosts')[:1]
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('shared-infra_hosts')[:1]
 
 
 @pytest.mark.test_id('d7fc4cdc-432a-11e8-a5dc-6a00035510c0')

--- a/molecule/default/tests/test_swift_recon_md5.py
+++ b/molecule/default/tests/test_swift_recon_md5.py
@@ -9,7 +9,7 @@ See RPC 10+ Post-Deployment QC process document
 """
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('os-infra_hosts')[:1]
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('shared-infra_hosts')[:1]
 
 
 @pytest.mark.test_id('d7fc49a8-432a-11e8-a2ea-6a00035510c0')

--- a/molecule/default/tests/test_swift_recon_unmount.py
+++ b/molecule/default/tests/test_swift_recon_unmount.py
@@ -9,7 +9,7 @@ See RPC 10+ Post-Deployment QC process document
 """
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('os-infra_hosts')[:1]
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('shared-infra_hosts')[:1]
 
 
 @pytest.mark.test_id('4b0691b8-8b9e-11e8-8fb0-a860b622fd2c')

--- a/molecule/default/tests/test_swift_ring_data_balance.py
+++ b/molecule/default/tests/test_swift_ring_data_balance.py
@@ -10,7 +10,7 @@ See RPC 10+ Post-Deployment QC process document
 """
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('os-infra_hosts')[:1]
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('shared-infra_hosts')[:1]
 
 rb_cmd_tmpl = "swift-ring-builder /etc/swift/{}.ring.gz"
 

--- a/molecule/default/tests/test_swift_stat.py
+++ b/molecule/default/tests/test_swift_stat.py
@@ -9,7 +9,7 @@ See RPC 10+ Post-Deployment QC process document
 """
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('os-infra_hosts')[:1]
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('shared-infra_hosts')[:1]
 
 
 @pytest.mark.test_id('d7fc4b42-432a-11e8-9ef9-6a00035510c0')

--- a/molecule/default/tests/test_write_to_attached_storage.py
+++ b/molecule/default/tests/test_write_to_attached_storage.py
@@ -10,7 +10,7 @@ from time import sleep
 on it, and verify you can write to it. """
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('os-infra_hosts')[:1]
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('shared-infra_hosts')[:1]
 
 os_pre = ("lxc-attach -n $(lxc-ls -1 | grep utility | head -n 1) "
           "-- bash -c '. /root/openrc ; openstack ")


### PR DESCRIPTION
This commit replaces the use of the legacy `os-infra_hosts` node group
with the `shared-infra_hosts` group.