### PR TITLE
ASC-1100 Use shared-infra_hosts

### DIFF
--- a/molecule/default/tests/test_cinder_attach.py
+++ b/molecule/default/tests/test_cinder_attach.py
@@ -9,7 +9,7 @@ import json
 
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('os-infra_hosts')[:1]
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('shared-infra_hosts')[:1]
 
 
 os_pre = ("lxc-attach -n $(lxc-ls -1 | grep utility | head -n 1) "

--- a/molecule/default/tests/test_cinder_lvm.py
+++ b/molecule/default/tests/test_cinder_lvm.py
@@ -10,7 +10,7 @@ RPC 10+ manual test 14.
 
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('os-infra_hosts')[:1]
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('shared-infra_hosts')[:1]
 
 
 os_pre = ("lxc-attach -n $(lxc-ls -1 | grep utility | head -n 1) "

--- a/molecule/default/tests/test_cinder_service.py
+++ b/molecule/default/tests/test_cinder_service.py
@@ -3,7 +3,7 @@ import pytest
 import testinfra.utils.ansible_runner
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('os-infra_hosts')[:1]
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('shared-infra_hosts')[:1]
 
 utility_container = ("lxc-attach -n $(lxc-ls -1 | grep utility | head -n 1) "
                      "-- bash -c '. /root/openrc ; ")

--- a/molecule/default/tests/test_cinder_volume.py
+++ b/molecule/default/tests/test_cinder_volume.py
@@ -10,7 +10,7 @@ RPC 10+ manual test 14.
 
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('os-infra_hosts')[:1]
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('shared-infra_hosts')[:1]
 
 
 utility_container = ("lxc-attach -n $(lxc-ls -1 | grep utility | head -n 1) "

--- a/molecule/default/tests/test_create_and_assign_floating_ip.py
+++ b/molecule/default/tests/test_create_and_assign_floating_ip.py
@@ -6,7 +6,7 @@ from time import sleep
 import json
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('os-infra_hosts')[:1]
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('shared-infra_hosts')[:1]
 
 utility_container = ("lxc-attach -n $(lxc-ls -1 | grep utility | head -n 1) "
                      "-- bash -c '. /root/openrc ; ")

--- a/molecule/default/tests/test_create_bootable_volume.py
+++ b/molecule/default/tests/test_create_bootable_volume.py
@@ -4,7 +4,7 @@ import pytest
 import testinfra.utils.ansible_runner
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('os-infra_hosts')[:1]
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('shared-infra_hosts')[:1]
 
 
 @pytest.mark.test_id('3c469966-4fcb-11e8-a604-6a0003552100')

--- a/molecule/default/tests/test_create_instance_from_bootable_volume.py
+++ b/molecule/default/tests/test_create_instance_from_bootable_volume.py
@@ -4,7 +4,7 @@ import pytest
 import testinfra.utils.ansible_runner
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('os-infra_hosts')[:1]
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('shared-infra_hosts')[:1]
 
 utility_container = ("lxc-attach -n $(lxc-ls -1 | grep utility | head -n 1) "
                      "-- bash -c '. /root/openrc ; ")

--- a/molecule/default/tests/test_create_snapshot_on_instance.py
+++ b/molecule/default/tests/test_create_snapshot_on_instance.py
@@ -5,7 +5,7 @@ import testinfra.utils.ansible_runner
 from time import sleep
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('os-infra_hosts')[:1]
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('shared-infra_hosts')[:1]
 
 utility_container = ("lxc-attach -n $(lxc-ls -1 | grep utility | head -n 1) "
                      "-- bash -c '. /root/openrc ; ")

--- a/molecule/default/tests/test_dhcp_agents.py
+++ b/molecule/default/tests/test_dhcp_agents.py
@@ -7,7 +7,7 @@ import pytest_rpc.helpers as helpers
 """ASC-157: Perform Post Deploy System validations"""
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('os-infra_hosts')[:1]
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('shared-infra_hosts')[:1]
 
 
 @pytest.mark.test_id('d7fc25ae-432a-11e8-a20a-6a00035510c0')

--- a/molecule/default/tests/test_env_scan.py
+++ b/molecule/default/tests/test_env_scan.py
@@ -6,7 +6,7 @@ import json
 """ASC-157: Perform Post Deploy System validations"""
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('os-infra_hosts')[:1]
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('shared-infra_hosts')[:1]
 
 os_pre = ("lxc-attach -n $(lxc-ls -1 | grep utility | head -n 1) "
           "-- bash -c '. /root/openrc ; openstack ")

--- a/molecule/default/tests/test_instance_per_network_per_hypervisor.py
+++ b/molecule/default/tests/test_instance_per_network_per_hypervisor.py
@@ -10,7 +10,7 @@ from time import sleep
 external ping, and tear-down """
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('os-infra_hosts')[:1]
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('shared-infra_hosts')[:1]
 
 os_pre = ("lxc-attach -n $(lxc-ls -1 | grep utility | head -n 1) "
           "-- bash -c '. /root/openrc ; openstack ")

--- a/molecule/default/tests/test_rpc_version.py
+++ b/molecule/default/tests/test_rpc_version.py
@@ -5,7 +5,7 @@ import re
 import pytest_rpc.helpers as helpers
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('os-infra_hosts')[:1]
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('shared-infra_hosts')[:1]
 
 
 @pytest.mark.test_id('2c596d8f-7957-11e8-8017-6a00035510c0')

--- a/molecule/default/tests/test_scan_images_and_flavors.py
+++ b/molecule/default/tests/test_scan_images_and_flavors.py
@@ -9,7 +9,7 @@ RPC 10+ manual test 10
 """
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('compute-infra_hosts')[:1]
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('shared-infra_hosts')[:1]
 
 # attach the utility container:
 attach_utility_container = "lxc-attach -n `lxc-ls -1 | grep utility | head -n 1` -- bash -c "

--- a/molecule/default/tests/test_swift_dispersion.py
+++ b/molecule/default/tests/test_swift_dispersion.py
@@ -10,7 +10,7 @@ See RPC 10+ Post-Deployment QC process document
 """
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('os-infra_hosts')[:1]
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('shared-infra_hosts')[:1]
 
 
 @pytest.mark.test_id('d7fc4cdc-432a-11e8-a5dc-6a00035510c0')

--- a/molecule/default/tests/test_swift_recon_md5.py
+++ b/molecule/default/tests/test_swift_recon_md5.py
@@ -9,7 +9,7 @@ See RPC 10+ Post-Deployment QC process document
 """
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('os-infra_hosts')[:1]
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('shared-infra_hosts')[:1]
 
 
 @pytest.mark.test_id('d7fc49a8-432a-11e8-a2ea-6a00035510c0')

--- a/molecule/default/tests/test_swift_recon_unmount.py
+++ b/molecule/default/tests/test_swift_recon_unmount.py
@@ -9,7 +9,7 @@ See RPC 10+ Post-Deployment QC process document
 """
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('os-infra_hosts')[:1]
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('shared-infra_hosts')[:1]
 
 
 @pytest.mark.test_id('4b0691b8-8b9e-11e8-8fb0-a860b622fd2c')

--- a/molecule/default/tests/test_swift_ring_data_balance.py
+++ b/molecule/default/tests/test_swift_ring_data_balance.py
@@ -10,7 +10,7 @@ See RPC 10+ Post-Deployment QC process document
 """
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('os-infra_hosts')[:1]
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('shared-infra_hosts')[:1]
 
 rb_cmd_tmpl = "swift-ring-builder /etc/swift/{}.ring.gz"
 

--- a/molecule/default/tests/test_swift_stat.py
+++ b/molecule/default/tests/test_swift_stat.py
@@ -9,7 +9,7 @@ See RPC 10+ Post-Deployment QC process document
 """
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('os-infra_hosts')[:1]
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('shared-infra_hosts')[:1]
 
 
 @pytest.mark.test_id('d7fc4b42-432a-11e8-9ef9-6a00035510c0')

--- a/molecule/default/tests/test_verify_configured_quotas.py
+++ b/molecule/default/tests/test_verify_configured_quotas.py
@@ -10,7 +10,7 @@ RPC 10+ manual test 8
 """
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('os-infra_hosts')[:1]
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('shared-infra_hosts')[:1]
 
 utility_container = ("lxc-attach -n $(lxc-ls -1 | grep utility | head -n 1) "
                      "-- bash -c '. /root/openrc ; ")

--- a/molecule/default/tests/test_verify_disabled_nova_force_config_drive.py
+++ b/molecule/default/tests/test_verify_disabled_nova_force_config_drive.py
@@ -8,7 +8,7 @@ import testinfra.utils.ansible_runner
 ################################################################
 # RPC 10+ manual test 1
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('compute-infra_hosts')[:1]
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('shared-infra_hosts')[:1]
 
 
 @pytest.mark.test_id('43e5ed40-4335-11e8-a701-6a00035510c0')

--- a/molecule/default/tests/test_verify_galera_cluster_after_reboot.py
+++ b/molecule/default/tests/test_verify_galera_cluster_after_reboot.py
@@ -14,7 +14,7 @@ All Nova hosts -> Log hosts -> Infra3 host -> Infra2 host -> Infra1 host -> All 
 """
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('os-infra_hosts')
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('shared-infra_hosts')
 
 galera_container = ("lxc-attach -n $(lxc-ls -1 | grep galera | head -n 1) -- ")
 

--- a/molecule/default/tests/test_verify_mbu_installed.py
+++ b/molecule/default/tests/test_verify_mbu_installed.py
@@ -10,7 +10,7 @@ import testinfra.utils.ansible_runner
 # Globals
 # ======================================================================================================================
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('os-infra_hosts')[:1]
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('shared-infra_hosts')[:1]
 
 
 backup_folder_on_host = '/openstack/backup'

--- a/molecule/default/tests/test_verify_networks_created.py
+++ b/molecule/default/tests/test_verify_networks_created.py
@@ -9,7 +9,7 @@ RPC 10+ manual test 9
 """
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('os-infra_hosts')[:1]
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('shared-infra_hosts')[:1]
 
 utility_container = ("lxc-attach -n $(lxc-ls -1 | grep utility | head -n 1) "
                      "-- bash -c '. /root/openrc ; ")

--- a/molecule/default/tests/test_verify_one_rabbitmp_channel_per_connection.py
+++ b/molecule/default/tests/test_verify_one_rabbitmp_channel_per_connection.py
@@ -9,7 +9,7 @@ RPC 10+ manual test 13
 """
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('os-infra_hosts')[:1]
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('shared-infra_hosts')[:1]
 
 # attach the rabbitMQ container:
 attach_rabbitmq_container = "lxc-attach -n `lxc-ls -1 | grep rabbit | head -n 1` -- "

--- a/molecule/default/tests/test_verify_users_and_tenants.py
+++ b/molecule/default/tests/test_verify_users_and_tenants.py
@@ -15,7 +15,7 @@ RPC 10+ manual test 7
 """
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('os-infra_hosts')[:1]
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('shared-infra_hosts')[:1]
 
 utility_container = ("lxc-attach -n $(lxc-ls -1 | grep utility | head -n 1) "
                      "-- bash -c '. /root/openrc ; ")

--- a/molecule/default/tests/test_write_to_attached_storage.py
+++ b/molecule/default/tests/test_write_to_attached_storage.py
@@ -10,7 +10,7 @@ from time import sleep
 on it, and verify you can write to it. """
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('os-infra_hosts')[:1]
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('shared-infra_hosts')[:1]
 
 os_pre = ("lxc-attach -n $(lxc-ls -1 | grep utility | head -n 1) "
           "-- bash -c '. /root/openrc ; openstack ")


### PR DESCRIPTION
This commit replaces the use of the legacy `os-infra_hosts` node group
with the `shared-infra_hosts` group.