### PR TITLE
ASC-1052 Fix remove router subnet

### DIFF
--- a/tasks/delete_existing_networks.yml
+++ b/tasks/delete_existing_networks.yml
@@ -37,8 +37,8 @@
   register: output
   with_items: "{{ router_list }}"
 
-# router_list: list of routers as strings. These are used as dictionary keys
-#     for the "routers" fact.
+# router_list: list of routers as strings. These are used as values for the
+#     "id" key in the "routers" fact.
 # output: dictionary containing "results" key with list of ansible results
 #     from port list for each router. Each list element contains a dictionary
 #     of the results for one router. The "stdout_lines" key contains a list of
@@ -62,29 +62,37 @@
 #        ]
 #    }
 #  Output:
-#    routers={ "first_router_id": [ "subnet_1a" ],
-#              "second_router_id": [ "subnet_2a" ]
-#            }
-- name: Set routers fact
+#    routers=[
+#        { "id": "first_router_id", "subnets": [ "subnet_1a" ] },
+#        { "id": "second_router_id", "subnets": [ "subnet_2a" ] }
+#            ]
+
+- name: Set routers_i fact
   set_fact:
-    routers: "{{ routers |default({}) | combine({item.0: item.1.stdout_lines}) }}"
+    routers_i: "{{ routers_i |default([]) + [ {'id': item.0, 'subnets': item.1.stdout_lines} ] }}"
   with_together:
     - "{{ router_list }}"
     - "{{ output.results }}"
 
-- name: Print routers
-  debug: var=routers
+- name: Print routers_i
+  debug: var=routers_i
+  when: routers_i is defined
 
-- name: Reset routers (with regex subnet_id)
+- name: Set routers (with regex subnet_id)
   set_fact:
-    routers: "{{ routers | combine(new_item, recursive=true) }}"
+    routers: "{{ routers |default([]) + [ new_item ] }}"
   vars:
     new_item: |-
-      { '{{item.key}}': {{ item.value | map('regex_replace', "^.*subnet_id='([-\w]+)'.*?$", '\1') | list }} }
-  with_dict: "{{ routers }}"
+      { 'id': '{{item.id}}',
+        'subnets': {{ item.subnets | map('regex_replace', "^.*subnet_id='([-\w]+)'.*?$", '\1') | list }}
+      }
+  with_items: "{{ routers_i }}"
+  when: routers_i is defined
 
 - name: Print routers
   debug: var=routers
+  when: routers is defined
+
 #################  End Router Data Collection  ##################
 
 ####################  Begin Remove Routers  #####################
@@ -99,13 +107,11 @@
   shell: |
     lxc-attach -n "{{ utility_container.stdout }}"  \
     -- bash -c '. /root/openrc ; \
-    openstack router remove subnet {{ item.key }} {{ item.value | join(" ") }}'
-  when:
-    - routers is defined
-    - item.value is defined
-    - item.value != ''
-    - item.value != []
-  with_dict: "{{ routers }}"
+    openstack router remove subnet {{ item.0.id }} {{ item.1 }}'
+  with_subelements:
+    - "{{ routers }}"
+    - subnets
+  when: routers is defined
 
 - name: Delete router
   shell: |
@@ -120,8 +126,11 @@
   shell: |
     lxc-attach -n "{{ utility_container.stdout }}"  \
     -- bash -c '. /root/openrc ; \
-    openstack subnet delete "{{ item.value | join(" ") }}"'
-  with_dict: "{{ routers }}"
+    openstack subnet delete {{ item.1 }}'
+  with_subelements:
+    - "{{ routers }}"
+    - subnets
+  when: routers is defined
 ####################  End Remove Subnets    #####################
 
 ####################  Begin Remove Networks #####################

--- a/tasks/delete_existing_networks.yml
+++ b/tasks/delete_existing_networks.yml
@@ -14,7 +14,7 @@
 # For each network
 #   openstack network delete network
 
-####################  Begin Remove Routers  #####################
+################  Begin Router Data Collection  #################
 - name: Get router list
   shell: |
     lxc-attach -n "{{ utility_container.stdout }}"  \
@@ -24,61 +24,104 @@
 
 - name: Set router list fact
   set_fact:
-    router_list_output: "{{ output.stdout_lines }}"
+    router_list: "{{ output.stdout_lines }}"
 
+- name: Print router list
+  debug: var=router_list
+
+- name: Get router ports
+  shell: |
+    lxc-attach -n "{{ utility_container.stdout }}"  \
+    -- bash -c '. /root/openrc ; \
+    openstack port list -f value --router "{{ item }}"'
+  register: output
+  with_items: "{{ router_list }}"
+
+# router_list: list of routers as strings. These are used as dictionary keys
+#     for the "routers" fact.
+# output: dictionary containing "results" key with list of ansible results
+#     from port list for each router. Each list element contains a dictionary
+#     of the results for one router. The "stdout_lines" key contains a list of
+#     the port data for the router. This data is then run through a regex
+#     filter to create a list of subnet_id values for the router.
+# Example:
+#  Input:
+#    router_list=['first_router_id', 'second_router_id']
+#    output={
+#        "results": [
+#        {
+#            "stdout_lines": [
+#                "first_port_key mac_addr ip_address='192.168.74.1', subnet_id='subnet_1a' ACTIVE"
+#            ]
+#        },
+#        {
+#            "stdout_lines": [
+#                "first_port_key mac_addr ip_address='192.168.74.1', subnet_id='subnet_2a' ACTIVE"
+#            ]
+#        }
+#        ]
+#    }
+#  Output:
+#    routers={ "first_router_id": [ "subnet_1a" ],
+#              "second_router_id": [ "subnet_2a" ]
+#            }
+- name: Set routers fact
+  set_fact:
+    routers: "{{ routers |default({}) | combine({item.0: item.1.stdout_lines}) }}"
+  with_together:
+    - "{{ router_list }}"
+    - "{{ output.results }}"
+
+- name: Print routers
+  debug: var=routers
+
+- name: Reset routers (with regex subnet_id)
+  set_fact:
+    routers: "{{ routers | combine(new_item, recursive=true) }}"
+  vars:
+    new_item: |-
+      { '{{item.key}}': {{ item.value | map('regex_replace', "^.*subnet_id='([-\w]+)'.*?$", '\1') | list }} }
+  with_dict: "{{ routers }}"
+
+- name: Print routers
+  debug: var=routers
+#################  End Router Data Collection  ##################
+
+####################  Begin Remove Routers  #####################
 - name: Unset external-gateway on router
   shell: |
     lxc-attach -n "{{ utility_container.stdout }}"  \
     -- bash -c '. /root/openrc ; \
     openstack router unset --external-gateway "{{ item }}"'
-  with_items: "{{ router_list_output }}"
-
-- name: Get router details
-  shell: |
-    lxc-attach -n "{{ utility_container.stdout }}"  \
-    -- bash -c '. /root/openrc ; \
-    openstack router show -f json "{{ item }}"'
-  register: output
-  with_items: "{{ router_list_output }}"
-
-- name: Set router details fact
-  set_fact:
-    router_details_output: "{{ output.results }}"
+  with_items: "{{ router_list }}"
 
 - name: Remove subnets from routers
   shell: |
     lxc-attach -n "{{ utility_container.stdout }}"  \
     -- bash -c '. /root/openrc ; \
-    openstack router remove subnet {{ (item.stdout | from_json).id }} {{ (item.stdout | from_json).interfaces_info | from_json | json_query("[*].subnet_id") | join(" ") }}'
-  when:  '(item.stdout | from_json).interfaces_info | from_json | json_query("[*].subnet_id") | join(" ")'
-  with_items: "{{ router_details_output }}"
+    openstack router remove subnet {{ item.key }} {{ item.value | join(" ") }}'
+  when:
+    - routers is defined
+    - item.value is defined
+    - item.value != ''
+    - item.value != []
+  with_dict: "{{ routers }}"
 
 - name: Delete router
   shell: |
     lxc-attach -n "{{ utility_container.stdout }}"  \
     -- bash -c '. /root/openrc ; \
     openstack router delete "{{ item }}"'
-  with_list: "{{ router_list_output }}"
+  with_list: "{{ router_list }}"
 ####################  End Remove Routers    #####################
 
 ####################  Begin Remove Subnets  #####################
-- name: Get subnets
-  shell: |
-    lxc-attach -n "{{ utility_container.stdout }}"  \
-    -- bash -c '. /root/openrc ; \
-    openstack subnet list -f value -c ID'
-  register: output
-
-- name: Set subnet list fact
-  set_fact:
-    subnet_list_output: "{{ output.stdout_lines }}"
-
 - name: Delete subnets
   shell: |
     lxc-attach -n "{{ utility_container.stdout }}"  \
     -- bash -c '. /root/openrc ; \
-    openstack subnet delete "{{ item }}"'
-  with_items: "{{ subnet_list_output }}"
+    openstack subnet delete "{{ item.value | join(" ") }}"'
+  with_dict: "{{ routers }}"
 ####################  End Remove Subnets    #####################
 
 ####################  Begin Remove Networks #####################


### PR DESCRIPTION
Pike is currently failing when attempting to delete the subnets on all
existing routers during the converge step.  This is caused by the
"router show" information for the router not containing the key
"interfaces_info", which causes the condition to prematurely fail due
to the undefined variable used in the template.

This commit updates the code to query for the ports associated with the
routers. The "subnet_id" values associated with these ports are used
rather than the "interfaces_info" value. The router ids and there
subnets are mapped together in order to simplify the variables used for
the removal of the routers and their underlying components.