### PR TITLE
(ASC-1140) Added checking server creating status

### DIFF
--- a/tasks/server_setup.yml
+++ b/tasks/server_setup.yml
@@ -10,3 +10,21 @@
     --nic net-id="{{ test_network }}" \
     --key-name "rpc_support" \
     "{{ test_server }}"'
+
+- name: List test server
+  shell: |
+    lxc-attach -n "{{ utility_container.stdout }}"  \
+    -- bash -c '. /root/openrc ; \
+    openstack server list | grep "{{ test_server }}"'
+  register: test_server_instance
+
+- name: Check test server status
+  shell: |
+    lxc-attach -n "{{ utility_container.stdout }}"  \
+    -- bash -c ". /root/openrc ; \
+    openstack server show -f value -c status \"{{ test_server }}\""
+  register: test_instance_status
+  until: test_instance_status.stdout.strip().lower() == 'active'
+  retries: 10
+  delay: 30
+  when: test_server_instance.rc == 0


### PR DESCRIPTION
System tests failed many tests in which a server needs to be created. During the server creation, the server status was seen to change from "Build" to "ERROR". It is unsure that there is at least one server has been successfully created, including the test_server created in server_setup.yml

This PR to add a step of checking if the server created in server_setup.yml is successful.