### PR TITLE
ASC-1180 Delegate OpenStack Ansible Connection Commands to Localhost

### DIFF
--- a/tasks/enable_api_access.yml
+++ b/tasks/enable_api_access.yml
@@ -25,13 +25,6 @@
     path: "{{ os_config_path }}"
     state: directory
 
-- name: Ensure 'shade' Python Package Installed on 'infra1' Host
-  pip:
-    name: "{{ item }}"
-    state: present
-  with_items:
-    - shade
-
 - name: Extract Raw Contents from 'infra1' Host
   block:
     - name: Attempt to Extract '{{ os_clouds_yaml_path }}' Contents from 'infra1' Host

--- a/tasks/volume_setup.yml
+++ b/tasks/volume_setup.yml
@@ -6,3 +6,4 @@
     display_name: "{{ test_volume }}"
     size: 1
     timeout: 600
+  delegate_to: localhost


### PR DESCRIPTION
It is not guaranteed that the 'infra1' host will have the prerequisites
satisfied in order to use the OpenStack Ansible connection plug-in.
Therefore, delegate said commands to localhost where there is tighter
control over the Python environment.