### PR TITLE
(ASC-1246) removed teardown in test level

### DIFF
--- a/molecule/default/tests/test_create_bootable_volume.py
+++ b/molecule/default/tests/test_create_bootable_volume.py
@@ -47,6 +47,3 @@ def test_create_bootable_volume(openstack_properties, host):
                                       'available',
                                       host,
                                       retries=50)
-
-    # Tear down
-    helpers.delete_volume(volume_name, host)


### PR DESCRIPTION
Prior to this PR, teardown in test_create_bootable_volume is handled in test level.
This causes the problem of deleting not-ready-for-deleting volume and cause the test failed.

This PR to remove the teardown and using openstack_properties fixture in conftest.py