### PR TITLE
ASC-1082 Add Back OS API Conn Support

### DIFF
--- a/molecule/default/tests/conftest.py
+++ b/molecule/default/tests/conftest.py
@@ -1,17 +1,50 @@
+# -*- coding: utf-8 -*-
+# ==============================================================================
+# Imports
+# ==============================================================================
 import pytest
+import openstack
 
 
-@pytest.fixture
+# ==============================================================================
+# Fixtures
+# ==============================================================================
+# TODO: these fixtures should be enhanced and moved to 'pytest-rpc'. (ASC-1253)
+@pytest.fixture(scope='module')
 def openstack_properties(host):
-    """ this fixture returns a static dictionary of data used for creating
-    openstack server (instance)"""
-    vars = host.ansible('include_vars', 'file=./vars/main.yml')['ansible_facts']
+    """This fixture returns a dictionary of OpenStack facts and variables from
+    Ansible which can be used to manipulate OpenStack objects. (i.e. create
+    server instances)
+
+    Args:
+        host(testinfra.host.Host): A hostname in dynamic_inventory.json or
+            molecule.yml
+
+    Returns:
+        dict: a static dictionary of data about OpenStack.
+    """
+
+    os_vars = host.ansible('include_vars',
+                           'file=./vars/main.yml')['ansible_facts']
 
     os_properties = {
         'image_name': 'Cirros-0.3.5',
-        'network_name': vars['gateway_network'],
-        'private_net': vars['private_network'],
+        'network_name': os_vars['gateway_network'],
+        'private_net': os_vars['private_network'],
         'flavor': 'm1.tiny',
         'zone': 'nova'
     }
+
     return os_properties
+
+
+@pytest.fixture(scope='session')
+def os_api_conn():
+    """Provide an authorized API connection to the 'default' cloud on the
+    OpenStack infrastructure.
+
+    Returns:
+        openstack.connection.Connection
+    """
+
+    return openstack.connect(cloud='default')


### PR DESCRIPTION
Add the "os_api_conn" fixture back after reverting #134. This time without
including the "glance_nfs_share_path" or "glance_nfs_share_path" variables.

~~This is blocked by #134 and needs to rebased before merge.~~