### PR TITLE
ASC-1222 Increase Timeout for Server Setup Converge Task

### DIFF
--- a/tasks/server_setup.yml
+++ b/tasks/server_setup.yml
@@ -10,4 +10,5 @@
     key_name: rpc_support
     security_groups: rpc-support
     auto_ip: false
+    timeout: 600
   delegate_to: localhost


### PR DESCRIPTION
Given the sporadic performance of our CI system, the timeout waiting for a
server instance to spawn should be increased to 10 minutes.