### PR TITLE
ASC-1342 Fix Missing Support Public Key Issue

### DIFF
--- a/tasks/support_key.yml
+++ b/tasks/support_key.yml
@@ -90,7 +90,7 @@
     cloud: default
     state: present
     name: rpc_support
-    public_key_file: "/root/.ssh/rpc_support.pub"
+    public_key: "{{ support_pub_key.content | b64decode }}"
   when:
     - support_pub_key.content |default('') |length > 64
   delegate_to: localhost


### PR DESCRIPTION
The 'rpc_support.pub' public key is not present on the deployment host which
causes the 'support_key.yml' to fail. Instead of writing the file to the
depoyment host the task was update to read the 'rpc_support.pub' key from
an existing variable.