### PR TITLE
ASC-1367 Fix "os_service_setup" Failure to Fail

### DIFF
--- a/tasks/os_service_setup.yml
+++ b/tasks/os_service_setup.yml
@@ -53,8 +53,7 @@
 - name: Run openstack-service-setup
   shell: |
     . /opt/molecule-test-env-on-sut/bin/activate
-    ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i "{{ inventory_file }}" openstack-service-setup.yml
-    deactivate
+    ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i "{{ inventory_file }}" openstack-service-setup.yml && deactivate
   args:
     executable: /bin/bash
     chdir: /opt/openstack-ansible-ops/multi-node-aio-xenial-ansible/playbooks/


### PR DESCRIPTION
The "deactivate" command would always succeed which would report that the
"Run openstack-service-setup" would always succeed regardless of what
actually happened.