### PR TITLE
ASC-1253 Automatically Extract OpenStack Properties from Ansible

### DIFF
--- a/molecule/default/tests/conftest.py
+++ b/molecule/default/tests/conftest.py
@@ -10,7 +10,7 @@ import openstack
 # Fixtures
 # ==============================================================================
 @pytest.fixture(scope='module')
-def openstack_properties(host):
+def os_props(host):
     """This fixture returns a dictionary of OpenStack facts and variables from
     Ansible which can be used to manipulate OpenStack objects. (i.e. create
     server instances)

--- a/molecule/default/tests/conftest.py
+++ b/molecule/default/tests/conftest.py
@@ -9,7 +9,6 @@ import openstack
 # ==============================================================================
 # Fixtures
 # ==============================================================================
-# TODO: these fixtures should be enhanced and moved to 'pytest-rpc'. (ASC-1253)
 @pytest.fixture(scope='module')
 def openstack_properties(host):
     """This fixture returns a dictionary of OpenStack facts and variables from
@@ -24,18 +23,10 @@ def openstack_properties(host):
         dict: a static dictionary of data about OpenStack.
     """
 
-    os_vars = host.ansible('include_vars',
-                           'file=./vars/main.yml')['ansible_facts']
+    os_props = host.ansible('include_vars',
+                            'file=./vars/main.yml')['ansible_facts']
 
-    os_properties = {
-        'image_name': 'Cirros-0.3.5',
-        'network_name': os_vars['gateway_network'],
-        'private_net': os_vars['private_network'],
-        'flavor': 'm1.tiny',
-        'zone': 'nova'
-    }
-
-    return os_properties
+    return os_props
 
 
 @pytest.fixture(scope='session')

--- a/molecule/default/tests/test_create_and_assign_floating_ip.py
+++ b/molecule/default/tests/test_create_and_assign_floating_ip.py
@@ -18,7 +18,7 @@ def test_assign_floating_ip_to_instance(openstack_properties, host):
 
     Args:
         openstack_properties (dict): fixture 'openstack_properties' from
-        conftest.py
+            conftest.py
         host(testinfra.host.Host): Testinfra host fixture.
     """
 
@@ -27,9 +27,9 @@ def test_assign_floating_ip_to_instance(openstack_properties, host):
     data = {
         'instance_name': "test_instance_{}".format(random_str),
         'from_source': 'image',
-        'source_name': openstack_properties['image_name'],
-        'flavor': openstack_properties['flavor'],
-        'network_name': openstack_properties['private_net'],
+        'source_name': openstack_properties['test_image_name'],
+        'flavor': openstack_properties['test_flavor'],
+        'network_name': openstack_properties['private_network'],
     }
 
     instance_id = helpers.create_instance(data, host)
@@ -54,7 +54,7 @@ def test_assign_floating_ip_to_instance(openstack_properties, host):
 
     # Creating a floating IP:
     floating_ip = helpers.create_floating_ip(
-        openstack_properties['network_name'],
+        openstack_properties['gateway_network'],
         host
     )
 

--- a/molecule/default/tests/test_create_and_assign_floating_ip.py
+++ b/molecule/default/tests/test_create_and_assign_floating_ip.py
@@ -13,12 +13,13 @@ utility_container = ("lxc-attach -n $(lxc-ls -1 | grep utility | head -n 1) "
 
 @pytest.mark.test_id('ab24ffbd-798b-11e8-a2b2-6c96cfdb2e43')
 @pytest.mark.jira('asc-254')
-def test_assign_floating_ip_to_instance(openstack_properties, host):
+def test_assign_floating_ip_to_instance(os_props, host):
     """ Assign floating IP to an instance/server
 
     Args:
-        openstack_properties (dict): fixture 'openstack_properties' from
-            conftest.py
+        os_props (dict): This fixture returns a dictionary of OpenStack facts
+            and variables from Ansible which can be used to manipulate
+            OpenStack objects.
         host(testinfra.host.Host): Testinfra host fixture.
     """
 
@@ -27,9 +28,9 @@ def test_assign_floating_ip_to_instance(openstack_properties, host):
     data = {
         'instance_name': "test_instance_{}".format(random_str),
         'from_source': 'image',
-        'source_name': openstack_properties['test_image_name'],
-        'flavor': openstack_properties['test_flavor'],
-        'network_name': openstack_properties['private_network'],
+        'source_name': os_props['test_resources']['image_name'],
+        'flavor': os_props['test_resources']['flavor'],
+        'network_name': os_props['private_network'],
     }
 
     instance_id = helpers.create_instance(data, host)
@@ -54,7 +55,7 @@ def test_assign_floating_ip_to_instance(openstack_properties, host):
 
     # Creating a floating IP:
     floating_ip = helpers.create_floating_ip(
-        openstack_properties['gateway_network'],
+        os_props['gateway_network'],
         host
     )
 

--- a/molecule/default/tests/test_create_and_assign_floating_ip.py
+++ b/molecule/default/tests/test_create_and_assign_floating_ip.py
@@ -28,8 +28,8 @@ def test_assign_floating_ip_to_instance(os_props, host):
     data = {
         'instance_name': "test_instance_{}".format(random_str),
         'from_source': 'image',
-        'source_name': os_props['test_resources']['image_name'],
-        'flavor': os_props['test_resources']['flavor'],
+        'source_name': os_props['osa_ops_resources']['image_name'],
+        'flavor': os_props['osa_ops_resources']['flavor'],
         'network_name': os_props['private_network'],
     }
 

--- a/molecule/default/tests/test_create_bootable_volume.py
+++ b/molecule/default/tests/test_create_bootable_volume.py
@@ -10,17 +10,18 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 @pytest.mark.test_id('3c469966-4fcb-11e8-a604-6a0003552100')
 @pytest.mark.jira('asc-258')
-def test_create_bootable_volume(openstack_properties, host):
+def test_create_bootable_volume(os_props, host):
     """Test to verify that a bootable volume can be created based on a
     Glance image
 
     Args:
-        openstack_properties (dict): fixture 'openstack_properties' from
-            conftest.py
+        os_props (dict): This fixture returns a dictionary of OpenStack facts
+            and variables from Ansible which can be used to manipulate
+            OpenStack objects.
         host(testinfra.host.Host): Testinfra host fixture.
     """
     image_id = helpers.get_id_by_name('image',
-                                      openstack_properties['test_image_name'],
+                                      os_props['test_resources']['image_name'],
                                       host)
     assert image_id is not None
 
@@ -30,7 +31,7 @@ def test_create_bootable_volume(openstack_properties, host):
     data = {'volume': {'size': '2',
                        'imageref': image_id,
                        'name': volume_name,
-                       'zone': openstack_properties['test_zone'],
+                       'zone': os_props['test_resources']['zone'],
                        }
             }
 

--- a/molecule/default/tests/test_create_bootable_volume.py
+++ b/molecule/default/tests/test_create_bootable_volume.py
@@ -30,7 +30,7 @@ def test_create_bootable_volume(os_props, host):
     random_str = helpers.generate_random_string(7)
     volume_name = "test_volume_{}".format(random_str)
 
-    data = {'volume': {'size': '2',
+    data = {'volume': {'size': '12',
                        'imageref': image_id,
                        'name': volume_name,
                        'zone': os_props['zone'],

--- a/molecule/default/tests/test_create_bootable_volume.py
+++ b/molecule/default/tests/test_create_bootable_volume.py
@@ -16,11 +16,11 @@ def test_create_bootable_volume(openstack_properties, host):
 
     Args:
         openstack_properties (dict): fixture 'openstack_properties' from
-        conftest.py
+            conftest.py
         host(testinfra.host.Host): Testinfra host fixture.
     """
     image_id = helpers.get_id_by_name('image',
-                                      openstack_properties['image_name'],
+                                      openstack_properties['test_image_name'],
                                       host)
     assert image_id is not None
 
@@ -30,7 +30,7 @@ def test_create_bootable_volume(openstack_properties, host):
     data = {'volume': {'size': '2',
                        'imageref': image_id,
                        'name': volume_name,
-                       'zone': openstack_properties['zone'],
+                       'zone': openstack_properties['test_zone'],
                        }
             }
 

--- a/molecule/default/tests/test_create_bootable_volume.py
+++ b/molecule/default/tests/test_create_bootable_volume.py
@@ -20,9 +20,11 @@ def test_create_bootable_volume(os_props, host):
             OpenStack objects.
         host(testinfra.host.Host): Testinfra host fixture.
     """
-    image_id = helpers.get_id_by_name('image',
-                                      os_props['test_resources']['image_name'],
-                                      host)
+    image_id = helpers.get_id_by_name(
+        'image',
+        os_props['osa_ops_resources']['image_name'],
+        host
+    )
     assert image_id is not None
 
     random_str = helpers.generate_random_string(7)
@@ -31,7 +33,7 @@ def test_create_bootable_volume(os_props, host):
     data = {'volume': {'size': '2',
                        'imageref': image_id,
                        'name': volume_name,
-                       'zone': os_props['test_resources']['zone'],
+                       'zone': os_props['zone'],
                        }
             }
 

--- a/molecule/default/tests/test_create_instance_from_bootable_volume.py
+++ b/molecule/default/tests/test_create_instance_from_bootable_volume.py
@@ -18,12 +18,12 @@ def create_bootable_volume(openstack_properties, host):
 
     Args:
         openstack_properties (dict): fixture 'openstack_properties' from
-        conftest.py
+            conftest.py
         host(testinfra.host.Host): Testinfra host fixture.
     """
 
     image_id = helpers.get_id_by_name('image',
-                                      openstack_properties['image_name'],
+                                      openstack_properties['test_image_name'],
                                       host)
     assert image_id is not None
 
@@ -33,7 +33,7 @@ def create_bootable_volume(openstack_properties, host):
     data = {'volume': {'size': '1',
                        'imageref': image_id,
                        'name': volume_name,
-                       'zone': openstack_properties['zone'],
+                       'zone': openstack_properties['test_zone'],
                        }
             }
 
@@ -64,13 +64,13 @@ def test_create_instance_from_bootable_volume(openstack_properties,
 
     Args:
         openstack_properties (dict): fixture 'openstack_properties' from
-        conftest.py
+            conftest.py
         create_bootable_volume: fixture 'create_bootable_volume'
-        host(testinfra.host.Host): Testinfra host fixture
+            host(testinfra.host.Host): Testinfra host fixture
     """
 
     network_id = helpers.get_id_by_name('network',
-                                        openstack_properties['network_name'],
+                                        openstack_properties['gateway_network'],
                                         host)
     assert network_id is not None
 
@@ -82,7 +82,7 @@ def test_create_instance_from_bootable_volume(openstack_properties,
            " --flavor {}"
            " --nic net-id={} {}'".format(utility_container,
                                          create_bootable_volume,
-                                         openstack_properties['flavor'],
+                                         openstack_properties['test_flavor'],
                                          network_id,
                                          instance_name)
            )

--- a/molecule/default/tests/test_create_instance_from_bootable_volume.py
+++ b/molecule/default/tests/test_create_instance_from_bootable_volume.py
@@ -23,9 +23,11 @@ def create_bootable_volume(os_props, host):
         host(testinfra.host.Host): Testinfra host fixture.
     """
 
-    image_id = helpers.get_id_by_name('image',
-                                      os_props['test_resources']['image_name'],
-                                      host)
+    image_id = helpers.get_id_by_name(
+        'image',
+        os_props['osa_ops_resources']['image_name'],
+        host
+    )
     assert image_id is not None
 
     random_str = helpers.generate_random_string(6)
@@ -34,7 +36,7 @@ def create_bootable_volume(os_props, host):
     data = {'volume': {'size': '1',
                        'imageref': image_id,
                        'name': volume_name,
-                       'zone': os_props['test_resources']['zone'],
+                       'zone': os_props['zone'],
                        }
             }
 
@@ -80,15 +82,18 @@ def test_create_instance_from_bootable_volume(os_props,
     random_str = helpers.generate_random_string(6)
     instance_name = "test_instance_{}".format(random_str)
 
-    cmd = ("{} openstack server create "
-           " --volume {}"
-           " --flavor {}"
-           " --nic net-id={} {}'".format(utility_container,
-                                         create_bootable_volume,
-                                         os_props['test_resources']['flavor'],
-                                         network_id,
-                                         instance_name)
-           )
+    cmd = (
+        "{} openstack server create "
+        " --volume {}"
+        " --flavor {}"
+        " --nic net-id={} {}'".format(
+            utility_container,
+            create_bootable_volume,
+            os_props['osa_ops_resources']['flavor'],
+            network_id,
+            instance_name
+        )
+    )
 
     host.run_expect([0], cmd)
 

--- a/molecule/default/tests/test_create_instance_from_bootable_volume.py
+++ b/molecule/default/tests/test_create_instance_from_bootable_volume.py
@@ -12,18 +12,19 @@ utility_container = ("lxc-attach -n $(lxc-ls -1 | grep utility | head -n 1) "
 
 
 @pytest.fixture
-def create_bootable_volume(openstack_properties, host):
+def create_bootable_volume(os_props, host):
     """Test to verify that a bootable volume can be created based on a
     Glance image
 
     Args:
-        openstack_properties (dict): fixture 'openstack_properties' from
-            conftest.py
+        os_props (dict): This fixture returns a dictionary of OpenStack facts
+            and variables from Ansible which can be used to manipulate
+            OpenStack objects.
         host(testinfra.host.Host): Testinfra host fixture.
     """
 
     image_id = helpers.get_id_by_name('image',
-                                      openstack_properties['test_image_name'],
+                                      os_props['test_resources']['image_name'],
                                       host)
     assert image_id is not None
 
@@ -33,7 +34,7 @@ def create_bootable_volume(openstack_properties, host):
     data = {'volume': {'size': '1',
                        'imageref': image_id,
                        'name': volume_name,
-                       'zone': openstack_properties['test_zone'],
+                       'zone': os_props['test_resources']['zone'],
                        }
             }
 
@@ -56,21 +57,23 @@ def create_bootable_volume(openstack_properties, host):
 
 @pytest.mark.test_id('8b701dbc-7584-11e8-ba5b-fe14fb7452aa')
 @pytest.mark.jira('asc-462')
-def test_create_instance_from_bootable_volume(openstack_properties,
+def test_create_instance_from_bootable_volume(os_props,
                                               create_bootable_volume,
                                               host):
     """Test to verify that a bootable volume can be created based on a
     Glance image
 
     Args:
-        openstack_properties (dict): fixture 'openstack_properties' from
-            conftest.py
+        os_props (dict): This fixture returns a dictionary of OpenStack facts
+            and variables from Ansible which can be used to manipulate
+            OpenStack objects.
         create_bootable_volume: fixture 'create_bootable_volume'
             host(testinfra.host.Host): Testinfra host fixture
+        host(testinfra.host.Host): Testinfra host fixture.
     """
 
     network_id = helpers.get_id_by_name('network',
-                                        openstack_properties['gateway_network'],
+                                        os_props['gateway_network'],
                                         host)
     assert network_id is not None
 
@@ -82,7 +85,7 @@ def test_create_instance_from_bootable_volume(openstack_properties,
            " --flavor {}"
            " --nic net-id={} {}'".format(utility_container,
                                          create_bootable_volume,
-                                         openstack_properties['test_flavor'],
+                                         os_props['test_resources']['flavor'],
                                          network_id,
                                          instance_name)
            )

--- a/molecule/default/tests/test_create_instance_from_bootable_volume.py
+++ b/molecule/default/tests/test_create_instance_from_bootable_volume.py
@@ -33,7 +33,7 @@ def create_bootable_volume(os_props, host):
     random_str = helpers.generate_random_string(6)
     volume_name = "test_volume_{}".format(random_str)
 
-    data = {'volume': {'size': '1',
+    data = {'volume': {'size': '12',
                        'imageref': image_id,
                        'name': volume_name,
                        'zone': os_props['zone'],

--- a/molecule/default/tests/test_create_snapshot_from_instance.py
+++ b/molecule/default/tests/test_create_snapshot_from_instance.py
@@ -20,15 +20,22 @@ snapshot_name = "test_snapshot_name_{}".format(random_str)
 @pytest.mark.jira('asc-259', 'asc-691')
 @pytest.mark.test_case_with_steps()
 class TestCreateSnapshotFromInstance(object):
-    def test_create_snapshot_of_an_instance(self, openstack_properties, host):
-        """Create an instance and then create snapshot on it"""
+    def test_create_snapshot_of_an_instance(self, os_props, host):
+        """Create an instance and then create snapshot on it
+
+        Args:
+            os_props (dict): This fixture returns a dictionary of OpenStack
+                facts and variables from Ansible which can be used to manipulate
+                OpenStack objects.
+            host(testinfra.host.Host): Testinfra host fixture.
+        """
 
         data_image = {
             "instance_name": instance_name,
             "from_source": 'image',
-            "source_name": openstack_properties['test_image_name'],
-            "flavor": openstack_properties['test_flavor'],
-            "network_name": openstack_properties['private_network'],
+            "source_name": os_props['test_resources']['image_name'],
+            "flavor": os_props['test_resources']['flavor'],
+            "network_name": os_props['private_network'],
         }
 
         helpers.create_instance(data_image, host)
@@ -67,14 +74,22 @@ class TestCreateSnapshotFromInstance(object):
                                           host,
                                           retries=20)
 
-    def test_create_instance_from_snapshot(self, openstack_properties, host):
+    def test_create_instance_from_snapshot(self, os_props, host):
+        """Create a new instance from an existing snapshot.
+
+        Args:
+            os_props (dict): This fixture returns a dictionary of OpenStack
+                facts and variables from Ansible which can be used to manipulate
+                OpenStack objects.
+            host(testinfra.host.Host): Testinfra host fixture.
+        """
 
         data_snapshot = {
             "instance_name": new_instance_name,
             "from_source": 'image',
             "source_name": snapshot_name,
-            "flavor": openstack_properties['test_flavor'],
-            "network_name": openstack_properties['private_network'],
+            "flavor": os_props['test_resources']['flavor'],
+            "network_name": os_props['private_network'],
         }
 
         # Boot new instance using the newly created snapshot:

--- a/molecule/default/tests/test_create_snapshot_from_instance.py
+++ b/molecule/default/tests/test_create_snapshot_from_instance.py
@@ -26,9 +26,9 @@ class TestCreateSnapshotFromInstance(object):
         data_image = {
             "instance_name": instance_name,
             "from_source": 'image',
-            "source_name": openstack_properties['image_name'],
-            "flavor": openstack_properties['flavor'],
-            "network_name": openstack_properties['private_net'],
+            "source_name": openstack_properties['test_image_name'],
+            "flavor": openstack_properties['test_flavor'],
+            "network_name": openstack_properties['private_network'],
         }
 
         helpers.create_instance(data_image, host)
@@ -73,8 +73,8 @@ class TestCreateSnapshotFromInstance(object):
             "instance_name": new_instance_name,
             "from_source": 'image',
             "source_name": snapshot_name,
-            "flavor": openstack_properties['flavor'],
-            "network_name": openstack_properties['private_net'],
+            "flavor": openstack_properties['test_flavor'],
+            "network_name": openstack_properties['private_network'],
         }
 
         # Boot new instance using the newly created snapshot:

--- a/molecule/default/tests/test_create_snapshot_from_instance.py
+++ b/molecule/default/tests/test_create_snapshot_from_instance.py
@@ -33,8 +33,8 @@ class TestCreateSnapshotFromInstance(object):
         data_image = {
             "instance_name": instance_name,
             "from_source": 'image',
-            "source_name": os_props['test_resources']['image_name'],
-            "flavor": os_props['test_resources']['flavor'],
+            "source_name": os_props['osa_ops_resources']['image_name'],
+            "flavor": os_props['osa_ops_resources']['flavor'],
             "network_name": os_props['private_network'],
         }
 
@@ -88,7 +88,7 @@ class TestCreateSnapshotFromInstance(object):
             "instance_name": new_instance_name,
             "from_source": 'image',
             "source_name": snapshot_name,
-            "flavor": os_props['test_resources']['flavor'],
+            "flavor": os_props['osa_ops_resources']['flavor'],
             "network_name": os_props['private_network'],
         }
 

--- a/molecule/default/tests/test_instance_per_network_per_hypervisor.py
+++ b/molecule/default/tests/test_instance_per_network_per_hypervisor.py
@@ -43,18 +43,23 @@ def create_server_on(target_host,
 
 @pytest.mark.test_id('c3002bde-59f1-11e8-be3b-6c96cfdb252f')
 @pytest.mark.jira('ASC-241', 'ASC-883', 'ASC-789', 'RI-417')
-def test_hypervisor_vms(host):
+def test_hypervisor_vms(host, os_props):
     """ASC-241: Per network, spin up an instance on each hypervisor, perform
-    external ping, and tear-down """
+    external ping, and tear-down
+
+    Args:
+        host(testinfra.host.Host): Testinfra host fixture.
+        os_props (dict): This fixture returns a dictionary of OpenStack
+            facts and variables from Ansible which can be used to manipulate
+            OpenStack objects.
+
+    """
 
     ssh = "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
            -i ~/.ssh/rpc_support ubuntu@{}"
 
-    vars = host.ansible('include_vars',
-                        'file=./vars/main.yml')['ansible_facts']
-
-    flavor_name = vars['flavor']['name']
-    image_name = vars['image']['name']
+    flavor_name = os_props['flavor']['name']
+    image_name = os_props['image']['name']
 
     server_list = []
     testable_networks = []

--- a/molecule/default/tests/test_instance_per_network_per_hypervisor.py
+++ b/molecule/default/tests/test_instance_per_network_per_hypervisor.py
@@ -58,8 +58,8 @@ def test_hypervisor_vms(host, os_props):
     ssh = "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
            -i ~/.ssh/rpc_support ubuntu@{}"
 
-    flavor_name = os_props['flavor']['name']
-    image_name = os_props['image']['name']
+    flavor_name = os_props['test_resources']['flavor']
+    image_name = os_props['test_resources']['image_name']
 
     server_list = []
     testable_networks = []

--- a/molecule/default/tests/test_instance_per_network_per_hypervisor.py
+++ b/molecule/default/tests/test_instance_per_network_per_hypervisor.py
@@ -59,7 +59,7 @@ def test_hypervisor_vms(host, os_props):
            -i ~/.ssh/rpc_support ubuntu@{}"
 
     flavor_name = os_props['test_resources']['flavor']
-    image_name = os_props['test_resources']['image_name']
+    image_name = os_props['osa_ops_resources']['image_name']
 
     server_list = []
     testable_networks = []

--- a/molecule/default/tests/test_write_to_attached_storage.py
+++ b/molecule/default/tests/test_write_to_attached_storage.py
@@ -54,12 +54,18 @@ def attach_volume_to_server(volume, server, run_on_host):
 
 @pytest.mark.test_id('3d77bc35-7a21-11e8-90d1-6a00035510c0')
 @pytest.mark.jira('ASC-257', 'ASC-883', 'RI-417')
-def test_volume_attached(host):
-    vars = host.ansible('include_vars',
-                        'file=./vars/main.yml')['ansible_facts']
+def test_volume_attached(host, os_props):
+    """Verify that data can be written to a volume attached to an instance.
 
-    server_name = vars['test_server']
-    volume_name = vars['test_volume']
+    Args:
+        host(testinfra.host.Host): Testinfra host fixture.
+        os_props (dict): This fixture returns a dictionary of OpenStack facts
+            and variables from Ansible which can be used to manipulate
+            OpenStack objects.
+    """
+
+    server_name = os_props['test_resources']['server']
+    volume_name = os_props['test_resources']['volume']
 
     floating_ip = helpers.create_floating_ip('GATEWAY_NET', host)
 

--- a/tasks/flavor_setup.yml
+++ b/tasks/flavor_setup.yml
@@ -3,7 +3,7 @@
   os_nova_flavor:
     cloud: default
     state: present
-    name: "{{ flavor.name }}"
+    name: "{{ test_resources.flavor }}"
     ram: 512
     vcpus: 1
     disk: 10

--- a/tasks/network_setup.yml
+++ b/tasks/network_setup.yml
@@ -3,7 +3,7 @@
   os_network:
     cloud: default
     state: present
-    name: "{{ test_network }}"
+    name: "{{ test_resources.network }}"
     external: false
   delegate_to: localhost
 
@@ -11,8 +11,8 @@
   os_subnet:
     cloud: default
     state: present
-    network_name: "{{ test_network }}"
-    name: "{{ test_subnet }}"
+    network_name: "{{ test_resources.network }}"
+    name: "{{ test_resources.subnet }}"
     cidr: 192.168.1.0/24
     allocation_pool_start: 192.168.1.2
     allocation_pool_end: 192.168.1.254
@@ -23,8 +23,8 @@
   os_router:
     cloud: default
     state: present
-    name: "{{ test_router }}"
+    name: "{{ test_resources.router }}"
     network: "{{ gateway_network }}"
     interfaces:
-      - "{{ test_subnet }}"
+      - "{{ test_resources.subnet }}"
   delegate_to: localhost

--- a/tasks/server_setup.yml
+++ b/tasks/server_setup.yml
@@ -3,10 +3,10 @@
   os_server:
     cloud: default
     state: present
-    name: "{{ test_server }}"
+    name: "{{ test_resources.server }}"
     image: "{{ image.name }}"
     flavor: "{{ flavor.name }}"
-    network: "{{ test_network }}"
+    network: "{{ test_resources.network }}"
     key_name: rpc_support
     security_groups: rpc-support
     auto_ip: false

--- a/tasks/server_setup.yml
+++ b/tasks/server_setup.yml
@@ -4,8 +4,8 @@
     cloud: default
     state: present
     name: "{{ test_resources.server }}"
-    image: "{{ image.name }}"
-    flavor: "{{ flavor.name }}"
+    image: "{{ test_resources.image_name }}"
+    flavor: "{{ test_resources.flavor }}"
     network: "{{ test_resources.network }}"
     key_name: rpc_support
     security_groups: rpc-support

--- a/tasks/server_setup.yml
+++ b/tasks/server_setup.yml
@@ -4,7 +4,7 @@
     cloud: default
     state: present
     name: "{{ test_resources.server }}"
-    image: "{{ test_resources.image_name }}"
+    image: "{{ osa_ops_resources.image_name }}"
     flavor: "{{ test_resources.flavor }}"
     network: "{{ test_resources.network }}"
     key_name: rpc_support

--- a/tasks/volume_setup.yml
+++ b/tasks/volume_setup.yml
@@ -3,7 +3,7 @@
   os_volume:
     cloud: default
     state: present
-    display_name: "{{ test_volume }}"
+    display_name: "{{ test_resources.volume }}"
     size: 1
     timeout: 600
   delegate_to: localhost

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -22,16 +22,14 @@ ops_apt_host_packages:
   - ntp
   - ntpdate
   - vlan
-image:
-  name: Ubuntu 16.04
-flavor:
-  name: post-deploy
 test_resources:
   server: post-deploy-server
   volume: post-deploy-volume
   router: TEST-ROUTER
   network: TEST-VXLAN
   subnet: TEST-VXLAN-SUBNET
+  flavor: post-deploy
+  image_name: Ubuntu 16.04
 osa_ops_resources:
   image_name: Cirros-0.3.5
   flavor: m1.tiny

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -31,6 +31,9 @@ test_volume: post-deploy-volume
 test_router: TEST-ROUTER
 test_network: TEST-VXLAN
 test_subnet: TEST-VXLAN-SUBNET
+test_image_name: Cirros-0.3.5
+test_flavor: m1.tiny
+test_zone: nova
 gateway_network: GATEWAY_NET
 private_network: PRIVATE_NET
 custom_fact_path: /etc/ansible/facts.d

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -29,10 +29,9 @@ test_resources:
   network: TEST-VXLAN
   subnet: TEST-VXLAN-SUBNET
   flavor: post-deploy
-  image_name: Ubuntu 16.04
 osa_ops_resources:
-  image_name: Cirros-0.3.5
-  flavor: m1.tiny
+  image_name: Ubuntu 16.04
+  flavor: m1.small
 zone: nova
 gateway_network: GATEWAY_NET
 private_network: PRIVATE_NET

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -32,9 +32,10 @@ test_resources:
   router: TEST-ROUTER
   network: TEST-VXLAN
   subnet: TEST-VXLAN-SUBNET
+osa_ops_resources:
   image_name: Cirros-0.3.5
   flavor: m1.tiny
-  zone: nova
+zone: nova
 gateway_network: GATEWAY_NET
 private_network: PRIVATE_NET
 custom_fact_path: /etc/ansible/facts.d

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -26,14 +26,15 @@ image:
   name: Ubuntu 16.04
 flavor:
   name: post-deploy
-test_server: post-deploy-server
-test_volume: post-deploy-volume
-test_router: TEST-ROUTER
-test_network: TEST-VXLAN
-test_subnet: TEST-VXLAN-SUBNET
-test_image_name: Cirros-0.3.5
-test_flavor: m1.tiny
-test_zone: nova
+test_resources:
+  server: post-deploy-server
+  volume: post-deploy-volume
+  router: TEST-ROUTER
+  network: TEST-VXLAN
+  subnet: TEST-VXLAN-SUBNET
+  image_name: Cirros-0.3.5
+  flavor: m1.tiny
+  zone: nova
 gateway_network: GATEWAY_NET
 private_network: PRIVATE_NET
 custom_fact_path: /etc/ansible/facts.d


### PR DESCRIPTION
Update the "openstack_properties" fixture to automatically extract all the
variables from Ansible. Also, I update the naming of the Ansible variables
to be consistent. Let me know if the naming is confusing.