### PR TITLE
(ASC-1393) reuse gen_dict_extract function

### DIFF
--- a/molecule/default/tests/test_dhcp_agents.py
+++ b/molecule/default/tests/test_dhcp_agents.py
@@ -3,6 +3,7 @@ import testinfra.utils.ansible_runner
 import pytest
 import json
 import pytest_rpc.helpers as helpers
+import utils as tmp_var
 
 """ASC-157: Perform Post Deploy System validations"""
 
@@ -17,9 +18,8 @@ def test_openvswitch(host):
     Ensure DHCP agents for all networks are up
     """
 
-    r = \
-        (host.ansible("setup")["ansible_facts"]["ansible_local"]
-            ["system_tests"]["rpc_product_release"])
+    r = next(tmp_var.gen_dict_extract('rpc_product_release',
+                                      host.ansible("setup")))
     expected_codename, expected_major = helpers.get_osa_version(r)
     print "expected_major: {}".format(expected_major)
     try:

--- a/molecule/default/tests/test_rpc_version.py
+++ b/molecule/default/tests/test_rpc_version.py
@@ -3,33 +3,10 @@ import testinfra.utils.ansible_runner
 import pytest
 import re
 import pytest_rpc.helpers as helpers
+import utils as tmp_var
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('shared-infra_hosts')[:1]
-
-
-def gen_dict_extract(key, var):
-    """Produce a generator that can iterate over all found values for a given
-    key in a given dictionary
-
-    Args:
-        key(str): key to lookup
-        var(dict): dictionary to recursively search
-
-    Returns: generator
-    """
-
-    if hasattr(var, 'iteritems'):
-        for k, v in var.iteritems():
-            if k == key:
-                yield v
-            if isinstance(v, dict):
-                for result in gen_dict_extract(key, v):
-                    yield result
-            elif isinstance(v, list):
-                for d in v:
-                    for result in gen_dict_extract(key, d):
-                        yield result
 
 
 @pytest.mark.test_id('2c596d8f-7957-11e8-8017-6a00035510c0')
@@ -42,7 +19,8 @@ def test_openstack_release_version(host):
             testinfra_hosts
     """
 
-    r = next(gen_dict_extract('rpc_product_release', host.ansible("setup")))
+    r = next(tmp_var.gen_dict_extract('rpc_product_release',
+                                      host.ansible("setup")))
     expected_codename, expected_major = helpers.get_osa_version(r)
 
     # Expected example:
@@ -68,7 +46,8 @@ def test_openstack_codename(host):
             testinfra_hosts
     """
 
-    r = next(gen_dict_extract('rpc_product_release', host.ansible("setup")))
+    r = next(tmp_var.gen_dict_extract('rpc_product_release',
+                                      host.ansible("setup")))
     expected_codename, expected_major = helpers.get_osa_version(r)
 
     # Expected example:

--- a/molecule/default/tests/utils.py
+++ b/molecule/default/tests/utils.py
@@ -127,3 +127,27 @@ def get_expected_value(resource_type,
     print(show_all_status(run_on_host))
 
     return False
+
+
+def gen_dict_extract(key, var):
+    """Produce a generator that can iterate over all found values for a given
+    key in a given dictionary
+
+    Args:
+        key(str): key to lookup
+        var(dict): dictionary to recursively search
+
+    Returns: generator
+    """
+
+    if hasattr(var, 'iteritems'):
+        for k, v in var.iteritems():
+            if k == key:
+                yield v
+            if isinstance(v, dict):
+                for result in gen_dict_extract(key, v):
+                    yield result
+            elif isinstance(v, list):
+                for d in v:
+                    for result in gen_dict_extract(key, d):
+                        yield result


### PR DESCRIPTION
Looking up for rpc_product_release has been changed recently in
commit 46760db71ee69387866a3cd0aa649ebb857630c3. The old way of
getting 'epc_product_release' is no longer working so it will
break other system tests (test_dhcp_agents.py and test_swift_stat.py).

This PR to relocate the method to utils.py file so other tests can
utilize it. Related test cases are also modified in this PR