### PR TITLE
ASC-1388 Follow symlink when looking up inventory

### DIFF
--- a/tasks/set_facts.yml
+++ b/tasks/set_facts.yml
@@ -65,7 +65,6 @@
 - name: Find the proper inventory file osp-mnaio
   shell: find /opt -name hosts -print
   register: find_inventory_file
-  ignore_errors: true
   when:
     - rpc_openstack is undefined
   delegate_to: localhost

--- a/tasks/set_facts.yml
+++ b/tasks/set_facts.yml
@@ -63,7 +63,7 @@
   delegate_to: localhost
 
 - name: Find the proper inventory file osp-mnaio
-  shell: find /opt -name hosts -print
+  shell: find -L /opt/osp-mnaio -name hosts -print
   register: find_inventory_file
   when:
     - rpc_openstack is undefined


### PR DESCRIPTION
This commit adds the '-L' flag to the find command for looking up the
inventory file for osp-mnaio.  Previous to this commit, if the repo was
cloned to a location other than `/opt` the find command would be unable
to locate the file.