### PR TITLE
ASC-1397 Increase Timeout for "os_service_setup" Converge Task

### DIFF
--- a/tasks/os_service_setup.yml
+++ b/tasks/os_service_setup.yml
@@ -57,7 +57,7 @@
   args:
     executable: /bin/bash
     chdir: /opt/openstack-ansible-ops/multi-node-aio-xenial-ansible/playbooks/
-  async: 1500
+  async: 2700
   poll: 60
 
 - name: create directory for ansible custome facts


### PR DESCRIPTION
Increase the timeout to 45 minutes to allow for more time to download OS images
which can experience erratic performance when downloading. (Thanks internet!)