### PR TITLE
(ASC-1365) Workaround for asc-1398

### DIFF
--- a/molecule/default/tests/test_swift_stat.py
+++ b/molecule/default/tests/test_swift_stat.py
@@ -26,6 +26,9 @@ def test_verify_swift_stat(host):
     if major < 17:
         result = helpers.run_on_swift(cmd, host)
     else:
+        # Work around for ASC-1398:
+        cmd = ". openrc ; " + cmd
+
         result = helpers.run_on_container(cmd, 'utility', host)
 
     assert 'Account: AUTH_' in result.stdout


### PR DESCRIPTION
Currently the function run_on_container in pytest-rpc cannot be used
without providing the authentication to Openstack (done by running
`source /path/openrc).

This PR is a workaround for that issue until asc-1398 is fixed.