### PR TITLE
Revert "ASC-1253 Automatically Extract OpenStack Properties from Ansible"

### DIFF
--- a/molecule/default/tests/conftest.py
+++ b/molecule/default/tests/conftest.py
@@ -9,8 +9,9 @@ import openstack
 # ==============================================================================
 # Fixtures
 # ==============================================================================
+# TODO: these fixtures should be enhanced and moved to 'pytest-rpc'. (ASC-1253)
 @pytest.fixture(scope='module')
-def os_props(host):
+def openstack_properties(host):
     """This fixture returns a dictionary of OpenStack facts and variables from
     Ansible which can be used to manipulate OpenStack objects. (i.e. create
     server instances)
@@ -23,10 +24,18 @@ def os_props(host):
         dict: a static dictionary of data about OpenStack.
     """
 
-    os_props = host.ansible('include_vars',
-                            'file=./vars/main.yml')['ansible_facts']
+    os_vars = host.ansible('include_vars',
+                           'file=./vars/main.yml')['ansible_facts']
 
-    return os_props
+    os_properties = {
+        'image_name': 'Cirros-0.3.5',
+        'network_name': os_vars['gateway_network'],
+        'private_net': os_vars['private_network'],
+        'flavor': 'm1.tiny',
+        'zone': 'nova'
+    }
+
+    return os_properties
 
 
 @pytest.fixture(scope='session')

--- a/molecule/default/tests/test_create_bootable_volume.py
+++ b/molecule/default/tests/test_create_bootable_volume.py
@@ -10,30 +10,27 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 @pytest.mark.test_id('3c469966-4fcb-11e8-a604-6a0003552100')
 @pytest.mark.jira('asc-258')
-def test_create_bootable_volume(os_props, host):
+def test_create_bootable_volume(openstack_properties, host):
     """Test to verify that a bootable volume can be created based on a
     Glance image
 
     Args:
-        os_props (dict): This fixture returns a dictionary of OpenStack facts
-            and variables from Ansible which can be used to manipulate
-            OpenStack objects.
+        openstack_properties (dict): fixture 'openstack_properties' from
+        conftest.py
         host(testinfra.host.Host): Testinfra host fixture.
     """
-    image_id = helpers.get_id_by_name(
-        'image',
-        os_props['osa_ops_resources']['image_name'],
-        host
-    )
+    image_id = helpers.get_id_by_name('image',
+                                      openstack_properties['image_name'],
+                                      host)
     assert image_id is not None
 
     random_str = helpers.generate_random_string(7)
     volume_name = "test_volume_{}".format(random_str)
 
-    data = {'volume': {'size': '12',
+    data = {'volume': {'size': '2',
                        'imageref': image_id,
                        'name': volume_name,
-                       'zone': os_props['zone'],
+                       'zone': openstack_properties['zone'],
                        }
             }
 

--- a/molecule/default/tests/test_create_snapshot_from_instance.py
+++ b/molecule/default/tests/test_create_snapshot_from_instance.py
@@ -20,22 +20,15 @@ snapshot_name = "test_snapshot_name_{}".format(random_str)
 @pytest.mark.jira('asc-259', 'asc-691')
 @pytest.mark.test_case_with_steps()
 class TestCreateSnapshotFromInstance(object):
-    def test_create_snapshot_of_an_instance(self, os_props, host):
-        """Create an instance and then create snapshot on it
-
-        Args:
-            os_props (dict): This fixture returns a dictionary of OpenStack
-                facts and variables from Ansible which can be used to manipulate
-                OpenStack objects.
-            host(testinfra.host.Host): Testinfra host fixture.
-        """
+    def test_create_snapshot_of_an_instance(self, openstack_properties, host):
+        """Create an instance and then create snapshot on it"""
 
         data_image = {
             "instance_name": instance_name,
             "from_source": 'image',
-            "source_name": os_props['osa_ops_resources']['image_name'],
-            "flavor": os_props['osa_ops_resources']['flavor'],
-            "network_name": os_props['private_network'],
+            "source_name": openstack_properties['image_name'],
+            "flavor": openstack_properties['flavor'],
+            "network_name": openstack_properties['private_net'],
         }
 
         helpers.create_instance(data_image, host)
@@ -74,22 +67,14 @@ class TestCreateSnapshotFromInstance(object):
                                           host,
                                           retries=20)
 
-    def test_create_instance_from_snapshot(self, os_props, host):
-        """Create a new instance from an existing snapshot.
-
-        Args:
-            os_props (dict): This fixture returns a dictionary of OpenStack
-                facts and variables from Ansible which can be used to manipulate
-                OpenStack objects.
-            host(testinfra.host.Host): Testinfra host fixture.
-        """
+    def test_create_instance_from_snapshot(self, openstack_properties, host):
 
         data_snapshot = {
             "instance_name": new_instance_name,
             "from_source": 'image',
             "source_name": snapshot_name,
-            "flavor": os_props['osa_ops_resources']['flavor'],
-            "network_name": os_props['private_network'],
+            "flavor": openstack_properties['flavor'],
+            "network_name": openstack_properties['private_net'],
         }
 
         # Boot new instance using the newly created snapshot:

--- a/molecule/default/tests/test_instance_per_network_per_hypervisor.py
+++ b/molecule/default/tests/test_instance_per_network_per_hypervisor.py
@@ -43,23 +43,18 @@ def create_server_on(target_host,
 
 @pytest.mark.test_id('c3002bde-59f1-11e8-be3b-6c96cfdb252f')
 @pytest.mark.jira('ASC-241', 'ASC-883', 'ASC-789', 'RI-417')
-def test_hypervisor_vms(host, os_props):
+def test_hypervisor_vms(host):
     """ASC-241: Per network, spin up an instance on each hypervisor, perform
-    external ping, and tear-down
-
-    Args:
-        host(testinfra.host.Host): Testinfra host fixture.
-        os_props (dict): This fixture returns a dictionary of OpenStack
-            facts and variables from Ansible which can be used to manipulate
-            OpenStack objects.
-
-    """
+    external ping, and tear-down """
 
     ssh = "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
            -i ~/.ssh/rpc_support ubuntu@{}"
 
-    flavor_name = os_props['test_resources']['flavor']
-    image_name = os_props['osa_ops_resources']['image_name']
+    vars = host.ansible('include_vars',
+                        'file=./vars/main.yml')['ansible_facts']
+
+    flavor_name = vars['flavor']['name']
+    image_name = vars['image']['name']
 
     server_list = []
     testable_networks = []

--- a/molecule/default/tests/test_write_to_attached_storage.py
+++ b/molecule/default/tests/test_write_to_attached_storage.py
@@ -54,18 +54,12 @@ def attach_volume_to_server(volume, server, run_on_host):
 
 @pytest.mark.test_id('3d77bc35-7a21-11e8-90d1-6a00035510c0')
 @pytest.mark.jira('ASC-257', 'ASC-883', 'RI-417')
-def test_volume_attached(host, os_props):
-    """Verify that data can be written to a volume attached to an instance.
+def test_volume_attached(host):
+    vars = host.ansible('include_vars',
+                        'file=./vars/main.yml')['ansible_facts']
 
-    Args:
-        host(testinfra.host.Host): Testinfra host fixture.
-        os_props (dict): This fixture returns a dictionary of OpenStack facts
-            and variables from Ansible which can be used to manipulate
-            OpenStack objects.
-    """
-
-    server_name = os_props['test_resources']['server']
-    volume_name = os_props['test_resources']['volume']
+    server_name = vars['test_server']
+    volume_name = vars['test_volume']
 
     floating_ip = helpers.create_floating_ip('GATEWAY_NET', host)
 

--- a/tasks/flavor_setup.yml
+++ b/tasks/flavor_setup.yml
@@ -3,7 +3,7 @@
   os_nova_flavor:
     cloud: default
     state: present
-    name: "{{ test_resources.flavor }}"
+    name: "{{ flavor.name }}"
     ram: 512
     vcpus: 1
     disk: 10

--- a/tasks/network_setup.yml
+++ b/tasks/network_setup.yml
@@ -3,7 +3,7 @@
   os_network:
     cloud: default
     state: present
-    name: "{{ test_resources.network }}"
+    name: "{{ test_network }}"
     external: false
   delegate_to: localhost
 
@@ -11,8 +11,8 @@
   os_subnet:
     cloud: default
     state: present
-    network_name: "{{ test_resources.network }}"
-    name: "{{ test_resources.subnet }}"
+    network_name: "{{ test_network }}"
+    name: "{{ test_subnet }}"
     cidr: 192.168.1.0/24
     allocation_pool_start: 192.168.1.2
     allocation_pool_end: 192.168.1.254
@@ -23,8 +23,8 @@
   os_router:
     cloud: default
     state: present
-    name: "{{ test_resources.router }}"
+    name: "{{ test_router }}"
     network: "{{ gateway_network }}"
     interfaces:
-      - "{{ test_resources.subnet }}"
+      - "{{ test_subnet }}"
   delegate_to: localhost

--- a/tasks/server_setup.yml
+++ b/tasks/server_setup.yml
@@ -3,10 +3,10 @@
   os_server:
     cloud: default
     state: present
-    name: "{{ test_resources.server }}"
-    image: "{{ osa_ops_resources.image_name }}"
-    flavor: "{{ test_resources.flavor }}"
-    network: "{{ test_resources.network }}"
+    name: "{{ test_server }}"
+    image: "{{ image.name }}"
+    flavor: "{{ flavor.name }}"
+    network: "{{ test_network }}"
     key_name: rpc_support
     security_groups: rpc-support
     auto_ip: false

--- a/tasks/volume_setup.yml
+++ b/tasks/volume_setup.yml
@@ -3,7 +3,7 @@
   os_volume:
     cloud: default
     state: present
-    display_name: "{{ test_resources.volume }}"
+    display_name: "{{ test_volume }}"
     size: 1
     timeout: 600
   delegate_to: localhost

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -22,17 +22,15 @@ ops_apt_host_packages:
   - ntp
   - ntpdate
   - vlan
-test_resources:
-  server: post-deploy-server
-  volume: post-deploy-volume
-  router: TEST-ROUTER
-  network: TEST-VXLAN
-  subnet: TEST-VXLAN-SUBNET
-  flavor: post-deploy
-osa_ops_resources:
-  image_name: Ubuntu 16.04
-  flavor: m1.small
-zone: nova
+image:
+  name: Ubuntu 16.04
+flavor:
+  name: post-deploy
+test_server: post-deploy-server
+test_volume: post-deploy-volume
+test_router: TEST-ROUTER
+test_network: TEST-VXLAN
+test_subnet: TEST-VXLAN-SUBNET
 gateway_network: GATEWAY_NET
 private_network: PRIVATE_NET
 custom_fact_path: /etc/ansible/facts.d


### PR DESCRIPTION
Reverts rcbops/molecule-rpc-openstack-post-deploy#157