### PR TITLE
ASC-1311 Refactor 'test_create_and_assign_floating_ip'

### DIFF
--- a/molecule/default/tests/conftest.py
+++ b/molecule/default/tests/conftest.py
@@ -104,15 +104,15 @@ def expect_os_property(os_api_conn,
     return False
 
 
-def ping(host, retries=10):
-    """Verify that a host can be pinged.
+def ping_from_mnaio(host_or_ip, retries=10):
+    """Verify that a host can be pinged from the MNAIO deployment host.
 
     Note: this function uses an exponential back-off for retries which means the
     more retries specified the longer the wait between each retry. The total
     wait time is on the fibonacci sequence. (https://bit.ly/1ee23o9)
 
     Args:
-        host (str): A valid hostname or IP address to ping.
+        host_or_ip (str): A valid hostname or IP address to ping.
         retries (int): The maximum number of retry attempts.
 
     Returns:
@@ -122,8 +122,8 @@ def ping(host, retries=10):
     # Ping command count option as function of OS
     param = '-n' if system().lower() == 'windows' else '-c'
 
-    # Building the command. Ex: "ping -c 1 google.com"
-    command = ['ping', param, '1', host]
+    # Building the command. Ex: "ping_from_mnaio -c 1 google.com"
+    command = ['ping_from_mnaio', param, '1', host_or_ip]
 
     # Pinging
     for attempt in range(1, retries + 1):

--- a/molecule/default/tests/test_create_and_assign_floating_ip.py
+++ b/molecule/default/tests/test_create_and_assign_floating_ip.py
@@ -1,79 +1,53 @@
-import pytest_rpc.helpers as helpers
-import os
+# -*- coding: utf-8 -*-
+"""ASC-240: Verify the requested glance images were uploaded
+
+RPC 10+ manual test 10
+"""
+# ==============================================================================
+# Imports
+# ==============================================================================
 import pytest
-import testinfra.utils.ansible_runner
-import utils as tmp_var
-
-testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('shared-infra_hosts')[:1]
-
-utility_container = ("lxc-attach -n $(lxc-ls -1 | grep utility | head -n 1) "
-                     "-- bash -c '. /root/openrc ; ")
+import pytest_rpc.helpers as helpers
+from conftest import ping
 
 
+# ==============================================================================
+# Test Cases
+# ==============================================================================
 @pytest.mark.test_id('ab24ffbd-798b-11e8-a2b2-6c96cfdb2e43')
-@pytest.mark.jira('asc-254')
-def test_assign_floating_ip_to_instance(openstack_properties, host):
-    """ Assign floating IP to an instance/server
+@pytest.mark.jira('ASC-254', 'ASC-1311')
+def test_assign_floating_ip_to_instance(os_api_conn,
+                                        create_server,
+                                        openstack_properties):
+    """Verify that a floating IP can be attached to a server instance.
 
     Args:
-        openstack_properties (dict): fixture 'openstack_properties' from
-        conftest.py
-        host(testinfra.host.Host): Testinfra host fixture.
+        os_api_conn (openstack.connection.Connection): An authorized API
+            connection to the 'default' cloud on the OpenStack infrastructure.
+        create_server (def): A factory function for generating servers.
+        openstack_properties (dict): OpenStack facts and variables from Ansible
+            which can be used to manipulate OpenStack objects.
     """
 
-    # Creating an instance from image
-    random_str = helpers.generate_random_string(6)
-    data = {
-        'instance_name': "test_instance_{}".format(random_str),
-        'from_source': 'image',
-        'source_name': openstack_properties['image_name'],
-        'flavor': openstack_properties['flavor'],
-        'network_name': openstack_properties['private_net'],
-    }
+    # Delete all unattached floating IPs.
+    os_api_conn.delete_unattached_floating_ips(retry=3)
 
-    instance_id = helpers.create_instance(data, host)
-
-    assert tmp_var.get_expected_value('server',
-                                      instance_id,
-                                      'status',
-                                      'ACTIVE',
-                                      host,
-                                      retries=40)
-    assert tmp_var.get_expected_value('server',
-                                      instance_id,
-                                      'OS-EXT-STS:power_state',
-                                      'Running',
-                                      host,
-                                      retries=20)
-    assert tmp_var.get_expected_value('server',
-                                      instance_id,
-                                      'OS-EXT-STS:vm_state',
-                                      'active', host,
-                                      retries=20)
-
-    # Creating a floating IP:
-    floating_ip = helpers.create_floating_ip(
-        openstack_properties['network_name'],
-        host
+    # Create server without floating IP. (Automatically validated by fixture)
+    test_server = create_server(
+        name="test_server_{}".format(helpers.generate_random_string()),
+        image=openstack_properties['cirros_image'],
+        flavor=openstack_properties['tiny_flavor'],
+        auto_ip=False,
+        network=openstack_properties['test_network'],
+        key_name=openstack_properties['key_name'],
+        security_groups=[openstack_properties['security_group']]
     )
 
-    # Assigning floating ip to a server
-    cmd = ("{} openstack server add "
-           "floating ip {} {}'".format(utility_container,
-                                       instance_id,
-                                       floating_ip)
-           )
-    host.run_expect([0], cmd)
+    # Create floating IP address and attach to test server.
+    floating_ip = os_api_conn.create_floating_ip(
+        wait=True,
+        server=test_server,
+        network=openstack_properties['network_name']
+    )
 
-    # After being assigned, the floating IP status should be 'ACTIVE'
-    assert (tmp_var.get_expected_value('floating ip',
-                                       floating_ip,
-                                       'status',
-                                       'ACTIVE',
-                                       host)
-            )
-
-    # Ensure the IP can be pinged from infra1
-    cmd = "ping -c1 {}".format(floating_ip)
-    assert (host.run_expect([0], cmd))
+    assert ping(floating_ip.floating_ip_address, retries=5)

--- a/molecule/default/tests/test_create_and_assign_floating_ip.py
+++ b/molecule/default/tests/test_create_and_assign_floating_ip.py
@@ -8,7 +8,7 @@ RPC 10+ manual test 10
 # ==============================================================================
 import pytest
 import pytest_rpc.helpers as helpers
-from conftest import ping
+from conftest import ping_from_mnaio
 
 
 # ==============================================================================
@@ -50,4 +50,4 @@ def test_assign_floating_ip_to_instance(os_api_conn,
         network=openstack_properties['network_name']
     )
 
-    assert ping(floating_ip.floating_ip_address, retries=5)
+    assert ping_from_mnaio(floating_ip.floating_ip_address, retries=5)

--- a/molecule/default/tests/test_create_snapshot_from_instance.py
+++ b/molecule/default/tests/test_create_snapshot_from_instance.py
@@ -47,7 +47,7 @@ def test_snapshot_instance(os_api_conn,
                               os_prop_name='status',
                               expected_value='active')
 
-    # # Create server from snapshot. (Automatically validated by fixture)
+    # Create server from snapshot. (Automatically validated by fixture)
     snapshot_server = create_server(
         name="snapshot_server_{}".format(helpers.generate_random_string()),
         image=snapshot_image,
@@ -58,11 +58,4 @@ def test_snapshot_instance(os_api_conn,
     )
 
     # Validate server was created from the snapshot image.
-    assert expect_os_property(
-        retries=10,
-        os_object=snapshot_server,
-        os_service='server',
-        os_api_conn=os_api_conn,
-        os_prop_name='image',
-        expected_value="{{u'id': u'{}'}}".format(snapshot_image.id),
-    )
+    assert snapshot_server.image.id == snapshot_image.id


### PR DESCRIPTION
**conftest**

Updated the 'create_server' factory in 'conftest' to allow for specifying
'auto_ip' upon server creation. Discovered a better way to validate the
properties after server creation. Added a beginning sleep because OpenStack
lies about waiting until something is actually done.

Updated 'expect_os_property' to provide more detailed information if a property
was not found on the given OpenStack object.

Added a 'ping' helper with retry support.

**test_create_and_assign_floating_ip**

Added a beginning clean-up step for removing unattached floating IPs because it
was the easiest way to guarantee that the floating IP pool is not exhausted.