### PR TITLE
ASC-1313 Refactor 'test_create_instance_from_bootable_volume'

### DIFF
--- a/molecule/default/tests/test_create_and_assign_floating_ip.py
+++ b/molecule/default/tests/test_create_and_assign_floating_ip.py
@@ -7,7 +7,6 @@ RPC 10+ manual test 10
 # Imports
 # ==============================================================================
 import pytest
-import pytest_rpc.helpers as helpers
 from conftest import ping_from_mnaio
 
 
@@ -34,7 +33,6 @@ def test_assign_floating_ip_to_instance(os_api_conn,
 
     # Create server without floating IP. (Automatically validated by fixture)
     test_server = create_server(
-        name="test_server_{}".format(helpers.generate_random_string()),
         image=openstack_properties['cirros_image'],
         flavor=openstack_properties['tiny_flavor'],
         auto_ip=False,

--- a/molecule/default/tests/test_create_instance_from_bootable_volume.py
+++ b/molecule/default/tests/test_create_instance_from_bootable_volume.py
@@ -1,113 +1,57 @@
-import pytest_rpc.helpers as helpers
-import os
+# -*- coding: utf-8 -*-
+# ==============================================================================
+# Imports
+# ==============================================================================
 import pytest
-import testinfra.utils.ansible_runner
-import utils as tmp_var
-
-testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('shared-infra_hosts')[:1]
-
-utility_container = ("lxc-attach -n $(lxc-ls -1 | grep utility | head -n 1) "
-                     "-- bash -c '. /root/openrc ; ")
+from conftest import ping_from_mnaio
 
 
-@pytest.fixture
-def create_bootable_volume(openstack_properties, host):
-    """Test to verify that a bootable volume can be created based on a
-    Glance image
-
-    Args:
-        openstack_properties (dict): fixture 'openstack_properties' from
-        conftest.py
-        host(testinfra.host.Host): Testinfra host fixture.
-    """
-
-    image_id = helpers.get_id_by_name('image',
-                                      openstack_properties['image_name'],
-                                      host)
-    assert image_id is not None
-
-    random_str = helpers.generate_random_string(6)
-    volume_name = "test_volume_{}".format(random_str)
-
-    data = {'volume': {'size': '1',
-                       'imageref': image_id,
-                       'name': volume_name,
-                       'zone': openstack_properties['zone'],
-                       }
-            }
-
-    volume_id = helpers.create_bootable_volume(data, host)
-    assert volume_id is not None
-
-    volumes = helpers.get_resource_list_by_name('volume', host)
-    assert volumes
-    volume_names = [x['Name'] for x in volumes]
-    assert volume_name in volume_names
-    assert tmp_var.get_expected_value('volume',
-                                      volume_name,
-                                      'status',
-                                      'available',
-                                      host,
-                                      retries=50)
-
-    return volume_id
-
-
+# ==============================================================================
+# Test Cases
+# ==============================================================================
 @pytest.mark.test_id('8b701dbc-7584-11e8-ba5b-fe14fb7452aa')
-@pytest.mark.jira('asc-462')
-def test_create_instance_from_bootable_volume(openstack_properties,
-                                              create_bootable_volume,
-                                              host):
+@pytest.mark.jira('ASC-462', 'ASC-1313')
+def test_create_instance_from_bootable_volume(os_api_conn,
+                                              create_volume,
+                                              create_server,
+                                              openstack_properties):
     """Test to verify that a bootable volume can be created based on a
-    Glance image
+    Glance image.
 
     Args:
-        openstack_properties (dict): fixture 'openstack_properties' from
-        conftest.py
-        create_bootable_volume: fixture 'create_bootable_volume'
-        host(testinfra.host.Host): Testinfra host fixture
+        os_api_conn (openstack.connection.Connection): An authorized API
+            connection to the 'default' cloud on the OpenStack infrastructure.
+        create_server (def): A factory function for generating servers.
+        create_volume (def): A factory function for generating volumes.
+        openstack_properties (dict): OpenStack facts and variables from Ansible
+            which can be used to manipulate OpenStack objects.
     """
 
-    network_id = helpers.get_id_by_name('network',
-                                        openstack_properties['network_name'],
-                                        host)
-    assert network_id is not None
+    # Delete all unattached floating IPs.
+    os_api_conn.delete_unattached_floating_ips(retry=3)
 
-    random_str = helpers.generate_random_string(6)
-    instance_name = "test_instance_{}".format(random_str)
+    # Create bootable volume.
+    test_volume = create_volume(
+        size=1,
+        image=openstack_properties['cirros_image'],
+        bootable=True
+    )
 
-    cmd = ("{} openstack server create "
-           " --volume {}"
-           " --flavor {}"
-           " --nic net-id={} {}'".format(utility_container,
-                                         create_bootable_volume,
-                                         openstack_properties['flavor'],
-                                         network_id,
-                                         instance_name)
-           )
+    # Create server without floating IP. (Automatically validated by fixture)
+    test_server = create_server(
+        flavor=openstack_properties['tiny_flavor'],
+        auto_ip=False,
+        network=openstack_properties['test_network'],
+        key_name=openstack_properties['key_name'],
+        boot_volume=test_volume,
+        security_groups=[openstack_properties['security_group']]
+    )
 
-    host.run_expect([0], cmd)
+    # Create floating IP address and attach to test server.
+    floating_ip = os_api_conn.create_floating_ip(
+        wait=True,
+        server=test_server,
+        network=openstack_properties['network_name']
+    )
 
-    instances = helpers.get_resource_list_by_name('server', host)
-    assert instances
-    instance_names = [x['Name'] for x in instances]
-    assert instance_name in instance_names
-    assert tmp_var.get_expected_value('server',
-                                      instance_name,
-                                      'status',
-                                      'ACTIVE',
-                                      host,
-                                      retries=30)
-    assert tmp_var.get_expected_value('server',
-                                      instance_name,
-                                      'OS-EXT-STS:power_state',
-                                      'Running',
-                                      host,
-                                      retries=20)
-    assert tmp_var.get_expected_value('server',
-                                      instance_name,
-                                      'OS-EXT-STS:vm_state',
-                                      'active',
-                                      host,
-                                      retries=20)
+    assert ping_from_mnaio(floating_ip.floating_ip_address, retries=5)

--- a/molecule/default/tests/test_create_snapshot_from_instance.py
+++ b/molecule/default/tests/test_create_snapshot_from_instance.py
@@ -7,7 +7,6 @@ RPC 10+ manual test 10
 # Imports
 # ==============================================================================
 import pytest
-import pytest_rpc.helpers as helpers
 from conftest import expect_os_property
 
 
@@ -49,7 +48,6 @@ def test_snapshot_instance(os_api_conn,
 
     # Create server from snapshot. (Automatically validated by fixture)
     snapshot_server = create_server(
-        name="snapshot_server_{}".format(helpers.generate_random_string()),
         image=snapshot_image,
         flavor=openstack_properties['tiny_flavor'],
         network=openstack_properties['test_network'],


### PR DESCRIPTION
Created a new 'create_volume' dynamic fixture for generating volumes.
I updated the 'create_server' fixture to allow for bootable volume. Also, I
dropped the 'name' required argument for 'create_server' as it was just noise
to keep typing given we don't care about the name at all.

~Blocked by #168~