### PR TITLE
ASC-1313 Maintenance on Refactored Code

### DIFF
--- a/molecule/default/tests/conftest.py
+++ b/molecule/default/tests/conftest.py
@@ -282,7 +282,7 @@ def create_server(os_api_conn, openstack_properties):
             wait=True,
             name="test_server_{}".format(helpers.generate_random_string()),
             flavor=flavor,
-            auto_ip=auto_ip,
+            auto_ip=False,
             network=network,
             timeout=timeout,
             key_name=key_name,
@@ -292,6 +292,21 @@ def create_server(os_api_conn, openstack_properties):
 
         # Sometimes the OpenStack object is not fully built even after waiting.
         sleep(2)
+
+        # Create floating IP address and attach to test server.
+        if auto_ip:
+            # TODO: The 'auto_ip' feature of 'create_server' is broken.
+            #   (ASC-1416)
+            # Delete all unattached floating IPs.
+            os_api_conn.delete_unattached_floating_ips(retry=3)
+
+            floating_ip = os_api_conn.create_floating_ip(
+                wait=True,
+                server=temp_server,
+                network=openstack_properties['network_name']
+            )
+
+            temp_server['accessIPv4'] = floating_ip.floating_ip_address
 
         shared_args = {'retries': retries,
                        'os_object': temp_server,

--- a/molecule/default/tests/test_create_and_assign_floating_ip.py
+++ b/molecule/default/tests/test_create_and_assign_floating_ip.py
@@ -15,37 +15,12 @@ from conftest import ping_from_mnaio
 # ==============================================================================
 @pytest.mark.test_id('ab24ffbd-798b-11e8-a2b2-6c96cfdb2e43')
 @pytest.mark.jira('ASC-254', 'ASC-1311')
-def test_assign_floating_ip_to_instance(os_api_conn,
-                                        create_server,
-                                        openstack_properties):
+def test_assign_floating_ip_to_instance(tiny_cirros_server):
     """Verify that a floating IP can be attached to a server instance.
 
     Args:
-        os_api_conn (openstack.connection.Connection): An authorized API
-            connection to the 'default' cloud on the OpenStack infrastructure.
-        create_server (def): A factory function for generating servers.
-        openstack_properties (dict): OpenStack facts and variables from Ansible
-            which can be used to manipulate OpenStack objects.
+        tiny_cirros_server (openstack.compute.v2.server.Server): Create a
+            'm1.tiny' server instance with a Cirros image.
     """
 
-    # Delete all unattached floating IPs.
-    os_api_conn.delete_unattached_floating_ips(retry=3)
-
-    # Create server without floating IP. (Automatically validated by fixture)
-    test_server = create_server(
-        image=openstack_properties['cirros_image'],
-        flavor=openstack_properties['tiny_flavor'],
-        auto_ip=False,
-        network=openstack_properties['test_network'],
-        key_name=openstack_properties['key_name'],
-        security_groups=[openstack_properties['security_group']]
-    )
-
-    # Create floating IP address and attach to test server.
-    floating_ip = os_api_conn.create_floating_ip(
-        wait=True,
-        server=test_server,
-        network=openstack_properties['network_name']
-    )
-
-    assert ping_from_mnaio(floating_ip.floating_ip_address, retries=5)
+    assert ping_from_mnaio(tiny_cirros_server.accessIPv4, retries=5)

--- a/molecule/default/tests/test_create_instance_from_bootable_volume.py
+++ b/molecule/default/tests/test_create_instance_from_bootable_volume.py
@@ -11,24 +11,18 @@ from conftest import ping_from_mnaio
 # ==============================================================================
 @pytest.mark.test_id('8b701dbc-7584-11e8-ba5b-fe14fb7452aa')
 @pytest.mark.jira('ASC-462', 'ASC-1313')
-def test_create_instance_from_bootable_volume(os_api_conn,
-                                              create_volume,
+def test_create_instance_from_bootable_volume(create_volume,
                                               create_server,
                                               openstack_properties):
     """Test to verify that a bootable volume can be created based on a
     Glance image.
 
     Args:
-        os_api_conn (openstack.connection.Connection): An authorized API
-            connection to the 'default' cloud on the OpenStack infrastructure.
         create_server (def): A factory function for generating servers.
         create_volume (def): A factory function for generating volumes.
         openstack_properties (dict): OpenStack facts and variables from Ansible
             which can be used to manipulate OpenStack objects.
     """
-
-    # Delete all unattached floating IPs.
-    os_api_conn.delete_unattached_floating_ips(retry=3)
 
     # Create bootable volume.
     test_volume = create_volume(
@@ -40,18 +34,10 @@ def test_create_instance_from_bootable_volume(os_api_conn,
     # Create server without floating IP. (Automatically validated by fixture)
     test_server = create_server(
         flavor=openstack_properties['tiny_flavor'],
-        auto_ip=False,
         network=openstack_properties['test_network'],
         key_name=openstack_properties['key_name'],
         boot_volume=test_volume,
         security_groups=[openstack_properties['security_group']]
     )
 
-    # Create floating IP address and attach to test server.
-    floating_ip = os_api_conn.create_floating_ip(
-        wait=True,
-        server=test_server,
-        network=openstack_properties['network_name']
-    )
-
-    assert ping_from_mnaio(floating_ip.floating_ip_address, retries=5)
+    assert ping_from_mnaio(test_server.accessIPv4, retries=5)


### PR DESCRIPTION
After doing some thinking about the fixtures I realized that I was typing way
too much extra code. I refactored the 'create_server' fixture to assign the
floating IP to an accessible property on the object. (See ASC-1416 for details
on the bug I found)

~Blocked by #169~