### PR TITLE
ASC-1341 Refactor 'test_create_bootable_volume'

### DIFF
--- a/molecule/default/tests/conftest.py
+++ b/molecule/default/tests/conftest.py
@@ -398,7 +398,7 @@ def create_volume(os_api_conn, openstack_properties):
         temp_volume = os_api_conn.create_volume(
             size=size,
             wait=True,
-            name="test_volume_".format(helpers.generate_random_string()),
+            name="test_volume_{}".format(helpers.generate_random_string()),
             image=image,
             timeout=timeout,
             bootable=bootable

--- a/molecule/default/tests/test_create_instance_from_bootable_volume.py
+++ b/molecule/default/tests/test_create_instance_from_bootable_volume.py
@@ -14,8 +14,7 @@ from conftest import ping_from_mnaio
 def test_create_instance_from_bootable_volume(create_volume,
                                               create_server,
                                               openstack_properties):
-    """Test to verify that a bootable volume can be created based on a
-    Glance image.
+    """Verify that a server can be created from a bootable volume.
 
     Args:
         create_server (def): A factory function for generating servers.


### PR DESCRIPTION
The test is pretty straightforward and utilzies fixtures that are already
available. I did fix a bug in the 'create_volume' fixture dealing with
naming newly created volumes. Also, I updated incorrect documentation I
ran into while copying and pasting from
'test_create_instance_from_bootable_volume.py'.