### PR TITLE
ASC-1396 Use geneve network type not vxlan

### DIFF
--- a/tasks/osp_osa_ops.yml
+++ b/tasks/osp_osa_ops.yml
@@ -38,6 +38,13 @@
     executable: /bin/bash
     chdir: /opt/openstack-ansible-ops/multi-node-aio-xenial-ansible/playbooks/vars
 
+- name: Hack the repo to set network type
+  shell: |
+    sed -i 's/network_type: vxlan/network_type: "{{ network_type }}"/' openstack-service-config.yml
+  args:
+    executable: /bin/bash
+    chdir: /opt/openstack-ansible-ops/multi-node-aio-xenial-ansible/playbooks/vars
+
 - name: install virtualenv
   package:
     name: python-virtualenv

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -53,6 +53,7 @@ private_net_cidr: 192.168.0.0/24
 private_subnet_name: "{{ private_net_name }}_SUBNET"
 # set this conditionally depending on OSP (datacentre) or RPC (flat)
 physical_network: datacentre
+network_type: geneve
 
 networks:
   - name: "{{ provider_net_name }}"
@@ -63,7 +64,7 @@ networks:
   - name: "{{ private_net_name }}"
     shared: true
     external: true
-    network_type: vxlan
+    network_type: "{{ network_type }}"
     segmentation_id: 101
 subnets:
   - name: "{{ provider_subnet_name }}"


### PR DESCRIPTION
OSP 13 deploys are currently not supporting `vxlan` network types.  The
`geneve` type appear to be the current default and supposedly supports all
of the functionality of `vxlan`.

This commit modifies the network type used by the openstack-ansible-ops
mnaio network creation script by dynamically replacing the `vxlan` value
for the `network_type` variable with the value of `geneve`.