### PR TITLE
ASC-1396 Fix undefined var in rabbitmq test

### DIFF
--- a/molecule/default/tests/test_verify_one_rabbitmp_channel_per_connection.py
+++ b/molecule/default/tests/test_verify_one_rabbitmp_channel_per_connection.py
@@ -20,6 +20,7 @@ def test_verify_rabbitmq_channel_per_connection(host):
     """
 
     # attach the rabbitMQ container:
+    attach_rabbitmq_container = ''
     try:
         rpc_release = host.ansible("setup")["ansible_facts"]["ansible_local"]["system_tests"]["rpc_product_release"]
         if rpc_release != '':


### PR DESCRIPTION
This commit fixes a condition where the `attach_rabbitmq_container`
variable could go undefined by the try logic that defines it.