### PR TITLE
ASC-1319 Refactor 'test_instance_per_network_per_hypervisor'

### DIFF
--- a/molecule/default/tests/test_instance_per_network_per_hypervisor.py
+++ b/molecule/default/tests/test_instance_per_network_per_hypervisor.py
@@ -149,7 +149,7 @@ def test_hypervisor_vms(neutron_cmd,
         if os_api_conn.get_subnet(gateway_id).gateway_ip:
             ssh = ("ssh -o StrictHostKeyChecking=no -o "
                    "UserKnownHostsFile=/dev/null "
-                   "-i ~/.ssh/rpc_support ubuntu@{}").format(server_ip)
+                   "-i ~/.ssh/rpc_support cirros@{}").format(server_ip)
 
             # ping out
             cmd = ("ip netns exec qdhcp-{} {} "

--- a/molecule/default/tests/test_instance_per_network_per_hypervisor.py
+++ b/molecule/default/tests/test_instance_per_network_per_hypervisor.py
@@ -1,166 +1,142 @@
-import os
-import testinfra.utils.ansible_runner
-import pytest
-import json
-from time import sleep
-import utils as tmp_var
-
+# -*- coding: utf-8 -*-
 """ASC-241: Per network, spin up an instance on each hypervisor, perform
-external ping, and tear-down """
+external ping, and tear-down."""
+# ==============================================================================
+# Imports
+# ==============================================================================
+import os
+import pytest
+import testinfra.utils.ansible_runner
+from time import sleep
 
+# ==============================================================================
+# Globals
+# ==============================================================================
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('shared-infra_hosts')[:1]
 
-os_pre = ("lxc-attach -n $(lxc-ls -1 | grep utility | head -n 1) "
-          "-- bash -c '. /root/openrc ; openstack ")
-os_post = "'"
 
+# ==============================================================================
+# Fixtures
+# ==============================================================================
+@pytest.fixture
+def neutron_cmd(host):
+    """Discover the optimal connection path to neutron agents and then provide
+    a helper factory for executing commands on the given neutron agent.
 
-def create_server_on(target_host,
-                     image_id,
-                     flavor,
-                     network_id,
-                     compute_zone,
-                     server_name):
-    cmd = "{} server create \
-           -f json \
-           --image {} \
-           --flavor {} \
-           --nic net-id={} \
-           --availability-zone {} \
-           --key-name 'rpc_support' \
-           {} {}".format(os_pre,
-                         image_id,
-                         flavor,
-                         network_id,
-                         compute_zone,
-                         server_name,
-                         os_post)
-    res = target_host.run(cmd)
-    server = json.loads(res.stdout)
-    return server
+    Args:
+        host(testinfra.host.Host): Testinfra host fixture.
 
+    Returns:
+        def: A factory function object.
 
-@pytest.mark.test_id('c3002bde-59f1-11e8-be3b-6c96cfdb252f')
-@pytest.mark.jira('ASC-241', 'ASC-883', 'ASC-789', 'RI-417')
-def test_hypervisor_vms(host):
-    """ASC-241: Per network, spin up an instance on each hypervisor, perform
-    external ping, and tear-down """
-
-    ssh = "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-           -i ~/.ssh/rpc_support ubuntu@{}"
-
-    vars = host.ansible('include_vars',
-                        'file=./vars/main.yml')['ansible_facts']
-
-    flavor_name = vars['flavor']['name']
-    image_name = vars['image']['name']
-
-    server_list = []
-    testable_networks = []
-
-    # get image id (sounds like a helper, or register it as an ansible value)
-    cmd = "{} image list -f json {}".format(os_pre, os_post)
-    res = host.run(cmd)
-    images = json.loads(res.stdout)
-    assert len(images) > 0
-    filtered_images = list(filter(lambda d: d['Name'] == image_name, images))
-    assert len(filtered_images) > 0
-    image = filtered_images[-1]
+    Raises:
+        AssertionError: Failure to discover a neutron agent.
+    """
 
     # neutron_agent connection lookup
     na_list = testinfra.utils.ansible_runner.AnsibleRunner(
         os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('neutron_agent')
     hostname = host.check_output('hostname')
+
     na_list = [x for x in na_list if hostname in x]
     neutron_agent = next(iter(na_list), None)
+
+    # Verify an agent was found
     assert neutron_agent
+
+    # Set neutron agent command prefix
     if 'container' in neutron_agent:
         # lxc
         na_pre = "lxc-attach -n {} -- bash -c ".format(neutron_agent)
     else:
         # ssh
-        na_pre = "ssh -o StrictHostKeyChecking=no \
-                   -o UserKnownHostsFile=/dev/null \
-                   {} ".format(neutron_agent)
+        na_pre = ("ssh -o StrictHostKeyChecking=no "
+                  "-o UserKnownHostsFile=/dev/null {} ").format(neutron_agent)
 
-    r = os.urandom(10).encode('hex')
+    def _factory(cmd):
+        """Execute a command on the given neutron agent.
 
-    # get list of internal networks
-    net_cmd = "{} network list -f json {}".format(os_pre, os_post)
-    net_res = host.run(net_cmd)
-    networks = json.loads(net_res.stdout)
-    for network in networks:
-        cmd = "{} network show {} -f json {}".format(os_pre,
-                                                     network['ID'],
-                                                     os_post)
-        res = host.run(cmd)
-        network_detail = json.loads(res.stdout)
-        if network_detail['router:external'] == 'External':
-            continue
-        testable_networks.append(network_detail)
+        Args:
+            cmd (str): Command to execute on given neutron agent.
+
+        Returns:
+            bool: True if command executes and returns an acceptable exit code,
+                otherwise False.
+        """
+
+        return host.run("{} '{}'".format(na_pre, cmd))
+
+    yield _factory
+
+
+# ==============================================================================
+# Test Cases
+# ==============================================================================
+@pytest.mark.test_id('c3002bde-59f1-11e8-be3b-6c96cfdb252f')
+@pytest.mark.jira('ASC-241', 'ASC-883', 'ASC-789', 'RI-417', 'ASC-1319')
+def test_hypervisor_vms(neutron_cmd,
+                        os_api_conn,
+                        create_server,
+                        openstack_properties):
+    """ASC-241: Per network, spin up an instance on each hypervisor, perform
+    external ping, and tear-down
+
+    Args:
+        neutron_cmd (def): Test fixture helper for executing commands on neutron
+            agents.
+        os_api_conn (openstack.connection.Connection): An authorized API
+            connection to the 'default' cloud on the OpenStack infrastructure.
+        create_server (def): A factory function for generating servers.
+        openstack_properties(dict): OpenStack facts and variables from Ansible
+            which can be used to manipulate OpenStack objects.
+    """
+
+    # Init
+    res = ''
+    server_list = []
+
+    # Get list of internal networks
+    testable_networks = os_api_conn.search_networks(
+        filters={'router:external': False}
+    )
 
     if not testable_networks:
-        pytest.skip("No testable networks found")
+        pytest.skip("No testable networks found!")
 
-    # iterate over internal networks
+    # Get list of compute availability zone names
+    # noinspection PyUnresolvedReferences
+    zones = [zone.name for zone in os_api_conn.compute.availability_zones()]
+
+    # Iterate over internal networks
     for network in testable_networks:
-        # spin up instance per hypervisor
-        cmd = "{} compute service list -f json {}".format(os_pre, os_post)
-        res = host.run(cmd)
-        computes = json.loads(res.stdout)
-        for compute in computes:
-            if compute['Binary'] == 'nova-compute':
-                instance_name = "rpctest-{}-{}-{}".format(r,
-                                                          compute['Host'],
-                                                          network['name'])
-                server = create_server_on(host,
-                                          image['ID'],
-                                          flavor_name,
-                                          network['id'],
-                                          compute['Zone'],
-                                          instance_name)
-                assert tmp_var.get_expected_value('server',
-                                                  server['id'],
-                                                  'OS-EXT-STS:power_state',
-                                                  'Running',
-                                                  host,
-                                                  retries=50)
-                assert tmp_var.get_expected_value('server',
-                                                  server['id'],
-                                                  'status',
-                                                  'ACTIVE',
-                                                  host,
-                                                  retries=30)
-                assert tmp_var.get_expected_value('server',
-                                                  server['id'],
-                                                  'OS-EXT-STS:vm_state',
-                                                  'active',
-                                                  host,
-                                                  retries=20)
-                server_list.append(server['id'])
+        # Create server per network per availability zone
+        for zone in zones:
+            server_list.append(create_server(
+                image=openstack_properties['cirros_image'],
+                flavor=openstack_properties['tiny_flavor'],
+                network=network['name'],
+                auto_ip=False,
+                key_name=openstack_properties['key_name'],
+                security_groups=[],
+                availability_zone=zone,
+                skip_teardown=True
+            ))
+
+    # Validate that at least one server was created
+    assert server_list
 
     for server in server_list:
-        # test ssh
-        print "DEBUG OUTPUT"
-        print server
-        cmd = "{} server show {} -f json {}".format(os_pre, server, os_post)
-        res = host.run(cmd)
-        server_detail = json.loads(res.stdout)
-        network_name, ip = server_detail['addresses'].split('=')
-        # get network detail (again)
-        # This will include network id and subnets.
-        cmd = "{} network show {} -f json {}".format(os_pre,
-                                                     network_name,
-                                                     os_post)
-        res = host.run(cmd)
-        network = json.loads(res.stdout)
+        network_name = server.addresses.keys()[0]
+        network_id = os_api_conn.get_network(network_name).id
+        server_ip = server.addresses[network_name][0]['addr']
+        gateway_id = os_api_conn.get_network(network_name).subnets[0]
 
-        # confirm SSH port access
-        cmd = "{} 'ip netns exec \
-               qdhcp-{} nc -w1 {} 22'".format(na_pre, network['id'], ip)
+        # Confirm SSH port access
+        cmd = "ip netns exec qdhcp-{} nc -w1 {} 22".format(network_id,
+                                                           server_ip)
         for attempt in range(60):
-            res = host.run(cmd)
+            res = neutron_cmd(cmd)
             try:
                 assert 'SSH' in res.stdout
             except AssertionError:
@@ -170,16 +146,12 @@ def test_hypervisor_vms(host):
         else:
             assert 'SSH' in res.stdout
 
-        # get gateway ip via subnet detail
-        cmd = "{} subnet show {} -f json {}".format(os_pre,
-                                                    network['subnets'],
-                                                    os_post)
-        res = host.run(cmd)
-        sub = json.loads(res.stdout)
-        if sub['gateway_ip']:
+        if os_api_conn.get_subnet(gateway_id).gateway_ip:
+            ssh = ("ssh -o StrictHostKeyChecking=no -o "
+                   "UserKnownHostsFile=/dev/null "
+                   "-i ~/.ssh/rpc_support ubuntu@{}").format(server_ip)
+
             # ping out
-            cmd = "{} 'ip netns exec \
-                   qdhcp-{} {} ping -c1 -w2 8.8.8.8'".format(na_pre,
-                                                             network['id'],
-                                                             ssh.format(ip))
-            host.run_expect([0], cmd)
+            cmd = ("ip netns exec qdhcp-{} {} "
+                   "ping -c1 -w2 8.8.8.8").format(network_id, ssh)
+            assert neutron_cmd(cmd).rc == 0


### PR DESCRIPTION
Rewrote the test to utilize the API when possible and re-organized the code
to be more readable.

I cannot get the test to pass in my environments and I'm all out of ideas on why. Output below showing failure:

```bash
                    # ping out
                    cmd = ("ip netns exec qdhcp-{} {} "
                           "ping -c1 -w2 8.8.8.8").format(network_id, ssh)
    >               assert neutron_cmd(cmd).rc == 0
    E               assert 255 == 0
    E                +  where 255 = CommandResult(command="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/...rmission denied, please try again.\r\nPermission denied (publickey,password).").rc
    E                +    where CommandResult(command="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/...rmission denied, please try again.\r\nPermission denied (publickey,password).") = <function _factory at 0x7f73a0351e60>('ip netns exec qdhcp-6c2fa1cb-1167-495b-9b04-d778670c258b ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ~/.ssh/rpc_support ubuntu@192.168.1.10 ping -c1 -w2 8.8.8.8')

    tests/test_ryan.py:157: AssertionError
    ---------------------------- Captured stderr setup -----------------------------
    INFO:testinfra:RUN Ansible(u'shell', 'hostname', {}): {'_ansible_no_log': False,
     '_ansible_parsed': True,
     u'changed': True,
     u'cmd': u'hostname',
     u'delta': u'0:00:00.003863',
     u'end': u'2019-01-10 19:12:59.956403',
     u'invocation': {u'module_args': {u'_raw_params': u'hostname',
                                      u'_uses_shell': True,
                                      u'chdir': None,
                                      u'creates': None,
                                      u'executable': None,
                                      u'removes': None,
                                      u'stdin': None,
                                      u'warn': True}},
     u'rc': 0,
     u'start': u'2019-01-10 19:12:59.952540',
     u'stderr': u'',
     'stderr_lines': [],
     u'stdout': u'infra1',
     'stdout_lines': [u'infra1']}
    INFO:testinfra:RUN CommandResult(command='hostname', exit_status=0, stdout=u'infra1', stderr=u'')
    ------------------------------ Captured log setup ------------------------------
    ansible.py                  61 INFO     RUN Ansible(u'shell', 'hostname', {}): {'_ansible_no_log': False,
     '_ansible_parsed': True,
     u'changed': True,
     u'cmd': u'hostname',
     u'delta': u'0:00:00.003863',
     u'end': u'2019-01-10 19:12:59.956403',
     u'invocation': {u'module_args': {u'_raw_params': u'hostname',
                                      u'_uses_shell': True,
                                      u'chdir': None,
                                      u'creates': None,
                                      u'executable': None,
                                      u'removes': None,
                                      u'stdin': None,
                                      u'warn': True}},
     u'rc': 0,
     u'start': u'2019-01-10 19:12:59.952540',
     u'stderr': u'',
     'stderr_lines': [],
     u'stdout': u'infra1',
     'stdout_lines': [u'infra1']}
    base.py                    241 INFO     RUN CommandResult(command='hostname', exit_status=0, stdout=u'infra1', stderr=u'')
    ----------------------------- Captured stderr call -----------------------------
    INFO:testinfra:RUN Ansible(u'shell', "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null infra1  'ip netns exec qdhcp-6c2fa1cb-1167-495b-9b04-d778670c258b nc -w1 192.168.1.10 22'", {}): {'_ansible_no_log': False,
     '_ansible_parsed': True,
     u'changed': True,
     u'cmd': u"ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null infra1 'ip netns exec qdhcp-6c2fa1cb-1167-495b-9b04-d778670c258b nc -w1 192.168.1.10 22'",
     u'delta': u'0:00:02.283009',
     u'end': u'2019-01-10 19:13:27.925697',
     u'invocation': {u'module_args': {u'_raw_params': u"ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null infra1 'ip netns exec qdhcp-6c2fa1cb-1167-495b-9b04-d778670c258b nc -w1 192.168.1.10 22'",
                                      u'_uses_shell': True,
                                      u'chdir': None,
                                      u'creates': None,
                                      u'executable': None,
                                      u'removes': None,
                                      u'stdin': None,
                                      u'warn': True}},
     u'msg': u'non-zero return code',
     u'rc': 1,
     u'start': u'2019-01-10 19:13:25.642688',
     u'stderr': u"Warning: Permanently added 'infra1' (ECDSA) to the list of known hosts.\r\n------------------------------------------------------------------------------\n* WARNING                                                                    *\n* You are accessing a secured system and your actions will be logged along   *\n* with identifying information. Disconnect immediately if you are not an     *\n* authorized user of this system.                                            *\n------------------------------------------------------------------------------",
     'stderr_lines': [u"Warning: Permanently added 'infra1' (ECDSA) to the list of known hosts.",
                      u'------------------------------------------------------------------------------',
                      u'* WARNING                                                                    *',
                      u'* You are accessing a secured system and your actions will be logged along   *',
                      u'* with identifying information. Disconnect immediately if you are not an     *',
                      u'* authorized user of this system.                                            *',
                      u'------------------------------------------------------------------------------'],
     u'stdout': u'',
     'stdout_lines': []}
    INFO:testinfra:RUN CommandResult(command="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null infra1  'ip netns exec qdhcp-6c2fa1cb-1167-495b-9b04-d778670c258b nc -w1 192.168.1.10 22'", exit_status=1, stdout=u'', stderr=u"Warning: Permanently added 'infra1' (ECDSA) to the list of known hosts.\r\n------------------------------------------------------------------------------\n* WARNING                                                                    *\n* You are accessing a secured system and your actions will be logged along   *\n* with identifying information. Disconnect immediately if you are not an     *\n* authorized user of this system.
                          *\n------------------------------------------------------------------------------")
    INFO:testinfra:RUN Ansible(u'shell', "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null infra1  'ip netns exec qdhcp-6c2fa1cb-1167-495b-9b04-d778670c258b nc -w1 192.168.1.10 22'", {}): {'_ansible_no_log': False,
     '_ansible_parsed': True,
     u'changed': True,
     u'cmd': u"ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null infra1 'ip netns exec qdhcp-6c2fa1cb-1167-495b-9b04-d778670c258b nc -w1 192.168.1.10 22'",
     u'delta': u'0:00:00.400489',
     u'end': u'2019-01-10 19:13:38.965136',
     u'invocation': {u'module_args': {u'_raw_params': u"ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null infra1 'ip netns exec qdhcp-6c2fa1cb-1167-495b-9b04-d778670c258b nc -w1 192.168.1.10 22'",
                                      u'_uses_shell': True,
                                      u'chdir': None,
                                      u'creates': None,
                                      u'executable': None,
                                      u'removes': None,
                                      u'stdin': None,
                                      u'warn': True}},
     u'rc': 0,
     u'start': u'2019-01-10 19:13:38.564647',
     u'stderr': u"Warning: Permanently added 'infra1' (ECDSA) to the list of known hosts.\r\n------------------------------------------------------------------------------\n* WARNING                                                                    *\n* You are accessing a secured system and your actions will be logged along   *\n* with identifying information. Disconnect immediately if you are not an     *\n* authorized user of this system.                                            *\n------------------------------------------------------------------------------",
     'stderr_lines': [u"Warning: Permanently added 'infra1' (ECDSA) to the list of known hosts.",
                      u'------------------------------------------------------------------------------',
                      u'* WARNING                                                                    *',
                      u'* You are accessing a secured system and your actions will be logged along   *',
                      u'* with identifying information. Disconnect immediately if you are not an     *',
                      u'* authorized user of this system.                                            *',
                      u'------------------------------------------------------------------------------'],
     u'stdout': u'SSH-2.0-dropbear_2012.55',
     'stdout_lines': [u'SSH-2.0-dropbear_2012.55']}
    INFO:testinfra:RUN CommandResult(command="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null infra1  'ip netns exec qdhcp-6c2fa1cb-1167-495b-9b04-d778670c258b nc -w1 192.168.1.10 22'", exit_status=0, stdout=u'SSH-2.0-dropbear_2012.55', stderr=u"Warning: Permanently added 'infra1' (ECDSA) to the list of known hosts.\r\n------------------------------------------------------------------------------\n* WARNING                                                                    *\n* You are accessing a secured system and your actions will be logged along   *\n* with identifying information. Disconnect immediately if you are not an     *\n* authorized user of this system.                                            *\n------------------------------------------------------------------------------")
    INFO:testinfra:RUN Ansible(u'shell', "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null infra1  'ip netns exec qdhcp-6c2fa1cb-1167-495b-9b04-d778670c258b ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ~/.ssh/rpc_support ubuntu@192.168.1.10 ping -c1 -w2 8.8.8.8'", {}): {'_ansible_no_log': False,
     '_ansible_parsed': True,
     u'changed': True,
     u'cmd': u"ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null infra1 'ip netns exec qdhcp-6c2fa1cb-1167-495b-9b04-d778670c258b ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ~/.ssh/rpc_support ubuntu@192.168.1.10 ping -c1 -w2 8.8.8.8'",
     u'delta': u'0:00:02.274610',
     u'end': u'2019-01-10 19:13:41.990473',
     u'invocation': {u'module_args': {u'_raw_params': u"ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null infra1 'ip netns exec qdhcp-6c2fa1cb-1167-495b-9b04-d778670c258b ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ~/.ssh/rpc_support ubuntu@192.168.1.10 ping -c1 -w2 8.8.8.8'",
                                      u'_uses_shell': True,
                                      u'chdir': None,
                                      u'creates': None,
                                      u'executable': None,
                                      u'removes': None,
                                      u'stdin': None,
                                      u'warn': True}},
     u'msg': u'non-zero return code',
     u'rc': 255,
     u'start': u'2019-01-10 19:13:39.715863',
     u'stderr': u"Warning: Permanently added 'infra1' (ECDSA) to the list of known hosts.\r\n------------------------------------------------------------------------------\n* WARNING                                                                    *\n* You are accessing a secured system and your actions will be logged along   *\n* with identifying information. Disconnect immediately if you are not an     *\n* authorized user of this system.                                            *\n------------------------------------------------------------------------------\nWarning: Permanently added '192.168.1.10' (RSA) to the list of known hosts.\r\nPermission denied, please try again.\r\nPermission denied, please try again.\r\nPermission denied (publickey,password).",
     'stderr_lines': [u"Warning: Permanently added 'infra1' (ECDSA) to the list of known hosts.",
                      u'------------------------------------------------------------------------------',
                      u'* WARNING                                                                    *',
                      u'* You are accessing a secured system and your actions will be logged along   *',
                      u'* with identifying information. Disconnect immediately if you are not an     *',
                      u'* authorized user of this system.                                            *',
                      u'------------------------------------------------------------------------------',
                      u"Warning: Permanently added '192.168.1.10' (RSA) to the list of known hosts.",
                      u'Permission denied, please try again.',
                      u'Permission denied, please try again.',
                      u'Permission denied (publickey,password).'],
     u'stdout': u'',
     'stdout_lines': []}
    INFO:testinfra:RUN CommandResult(command="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null infra1  'ip netns exec qdhcp-6c2fa1cb-1167-495b-9b04-d778670c258b ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ~/.ssh/rpc_support ubuntu@192.168.1.10 ping -c1 -w2 8.8.8.8'", exit_status=255, stdout=u'', stderr=u"Warning: Permanently added 'infra1' (ECDSA) to the list of known hosts.\r\n------------------------------------------------------------------------------\n* WARNING
                                                               *\n* You are accessing a secured system and your actions will be logged along   *\n* with identifying information. Disconnect immediately if you are not an     *\n* authorized user of this system.                                            *\n------------------------------------------------------------------------------\nWarning: Permanently added '192.168.1.10' (RSA) to the list of known hosts.\r\nPermission denied, please try again.\r\nPermission denied, please try again.\r\nPermission denied (publickey,password).")
```