### PR TITLE
ASC-1318 Refactor 'test_hypervisor_free'

### DIFF
--- a/molecule/default/tests/test_hypervisor_free.py
+++ b/molecule/default/tests/test_hypervisor_free.py
@@ -1,93 +1,93 @@
-import os
-import testinfra.utils.ansible_runner
-import pytest
-import json
-
+# -*- coding: utf-8 -*-
 """ASC-157: Perform Post Deploy System validations"""
+# ==============================================================================
+# Imports
+# ==============================================================================
+import os
+import pytest
+import testinfra.utils.ansible_runner
+from configparser import ConfigParser, NoOptionError
 
-target_host = 'infra1'
+# ==============================================================================
+# Globals
+# ==============================================================================
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts(target_host)
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('nova_compute')[:1]
 
 
+# ==============================================================================
+# Fixtures
+# ==============================================================================
 @pytest.fixture
-def get_nova_allocation_ratios(host):
-    """Retrieve resource allocation ratios from nova_conductor host.
+def nova_alloc_ratios(host):
+    """Retrieve resource allocation ratios from 'nova_compute' host.
 
     Args:
-        host (testinfra.Host): Testinfra host object to execute the action on.
+        host (testinfra.host.Host): Testinfra host fixture.
 
     Returns:
         dict: Ratios
     """
 
-    # Find the 'nova_conductor' container that corresponds with the
-    # 'target_host'
-    nova_conductor_containers = testinfra.utils.ansible_runner.AnsibleRunner(
-        os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('nova_conductor')
-    host_containers = testinfra.utils.ansible_runner.AnsibleRunner(
-        os.environ['MOLECULE_INVENTORY_FILE']).get_hosts(
-            target_host + '-host_containers')
-    nova_conductors = [i for i in nova_conductor_containers if i in set(
-        host_containers)]
-    assert len(nova_conductors) > 0
-    nova_conductor = nova_conductors[0]
+    # Setup
+    nova_conf_raw_file = host.file('/etc/nova/nova.conf').content_string
+    conf = ConfigParser()
+    conf.read_string(nova_conf_raw_file)
+    ratios = {}
 
-    os_pre = "lxc-attach -n {} -- bash -c \" ".format(nova_conductor)
-    cmd = ' '.join(["awk -F= '/^cpu_allocation_ratio/ {print $2}'",
-                    "/etc/nova/nova.conf"])
-    cpu_res = host.run("{} {}\"".format(os_pre, cmd))
-    cmd = ' '.join(["awk -F= '/^ram_allocation_ratio/ {print $2}'",
-                    "/etc/nova/nova.conf"])
-    ram_res = host.run("{} {}\"".format(os_pre, cmd))
-    cmd = ' '.join(["awk -F= '/^disk_allocation_ratio/ {print $2}'",
-                    "/etc/nova/nova.conf"])
-    disk_res = host.run("{} {}\"".format(os_pre, cmd))
-    cpu_ratio = (1 if not cpu_res.stdout.strip().replace(".", "", 1).isdigit()
-                 else (float)(cpu_res.stdout)
-                 )
-    ram_ratio = (1 if not ram_res.stdout.strip().replace(".", "", 1).isdigit()
-                 else (float)(ram_res.stdout)
-                 )
-    disk_ratio = (1 if not disk_res.stdout.strip().replace(".", "", 1).isdigit()
-                  else (float)(disk_res.stdout)
-                  )
-    assert cpu_res.rc == 0
-    assert ram_res.rc == 0
-    assert disk_res.rc == 0
+    try:
+        ratios['cpu_ratio'] = conf.getfloat('DEFAULT', 'cpu_allocation_ratio')
+    except NoOptionError:
+        ratios['cpu_ratio'] = 1.0
 
-    ratios = {
-        'cpu_ratio': cpu_ratio,
-        'ram_ratio': ram_ratio,
-        'disk_ratio': disk_ratio
-    }
+    try:
+        ratios['ram_ratio'] = conf.getfloat('DEFAULT', 'ram_allocation_ratio')
+    except NoOptionError:
+        ratios['ram_ratio'] = 1.0
+
+    try:
+        ratios['disk_ratio'] = conf.getfloat('DEFAULT', 'disk_allocation_ratio')
+    except NoOptionError:
+        ratios['disk_ratio'] = 1.0
 
     return ratios
 
 
+# ==============================================================================
+# Test Cases
+# ==============================================================================
 @pytest.mark.test_id('d7fc518c-432a-11e8-9015-6a00035510c0')
-@pytest.mark.jira('asc-157')
-def test_hypervisor_free(get_nova_allocation_ratios, host):
-    """Validate the resource levels for hypervisor"""
+@pytest.mark.jira('ASC-157', 'ASC-1318')
+def test_hypervisor_free(os_api_conn, nova_alloc_ratios):
+    """Validate the resource levels for hypervisor
 
-    os_pre = ("lxc-attach -n $(lxc-ls -1 | grep utility | head -n 1) "
-              "-- bash -c '. /root/openrc ; openstack ")
-    cmd = "{} hypervisor stats show -f json'".format(os_pre)
-    res = host.run(cmd)
-    stats = json.loads(res.stdout)
-    assert res.rc == 0
-    check_items = ['memory_mb',
-                   'memory_mb_used',
-                   'vcpus',
-                   'vcpus_used',
-                   'free_disk_gb']
+    Args:
+        os_api_conn (openstack.connection.Connection): An authorized API
+            connection to the 'default' cloud on the OpenStack infrastructure.
+        nova_alloc_ratios (dict): Resource allocation ratios from 'nova_compute'
+            host.
+    """
 
-    for item in check_items:
-        assert item in stats
+    # Setup
+    # noinspection PyUnresolvedReferences
+    hypervisors = [hv.to_dict()
+                   for hv in os_api_conn.compute.hypervisors(details=True)]
 
-    assert ((stats['memory_mb']) * get_nova_allocation_ratios['ram_ratio']
-            - (stats['memory_mb_used'])) / 1024 > 0
-    assert (stats['vcpus'] * get_nova_allocation_ratios['cpu_ratio']
-            - stats['vcpus_used']) > 0
-    assert (stats['free_disk_gb']
-            * get_nova_allocation_ratios['disk_ratio']) > 0
+    # Expect
+    expected_stats = ['memory_free',
+                      'memory_used',
+                      'vcpus',
+                      'vcpus_used',
+                      'disk_available']
+
+    # Test
+    for hypervisor in hypervisors:
+        for expected_stat in expected_stats:
+            assert expected_stat in hypervisor
+
+        assert ((hypervisor['memory_free']) * nova_alloc_ratios['ram_ratio']
+                - (hypervisor['memory_used'])) / 1024 > 0
+        assert (hypervisor['vcpus'] * nova_alloc_ratios['cpu_ratio']
+                - hypervisor['vcpus_used']) > 0
+        assert (hypervisor['disk_available']
+                * nova_alloc_ratios['disk_ratio']) > 0

--- a/molecule/default/tests/test_hypervisor_free.py
+++ b/molecule/default/tests/test_hypervisor_free.py
@@ -74,7 +74,7 @@ def test_hypervisor_free(os_api_conn, nova_alloc_ratios):
                    for hv in os_api_conn.compute.hypervisors(details=True)]
 
     # Expect
-    expected_stats = ['memory_free',
+    expected_stats = ['memory_size',
                       'memory_used',
                       'vcpus',
                       'vcpus_used',
@@ -85,7 +85,7 @@ def test_hypervisor_free(os_api_conn, nova_alloc_ratios):
         for expected_stat in expected_stats:
             assert expected_stat in hypervisor
 
-        assert ((hypervisor['memory_free']) * nova_alloc_ratios['ram_ratio']
+        assert ((hypervisor['memory_size']) * nova_alloc_ratios['ram_ratio']
                 - (hypervisor['memory_used'])) / 1024 > 0
         assert (hypervisor['vcpus'] * nova_alloc_ratios['cpu_ratio']
                 - hypervisor['vcpus_used']) > 0


### PR DESCRIPTION
Updated the test to use the API as well as grab the 'nova.conf' from the
'nova_compute' host group instead of the 'nova_conductor'.