### PR TITLE
ASC-1327 Refactor 'test_swift_stat'

### DIFF
--- a/molecule/default/tests/test_swift_stat.py
+++ b/molecule/default/tests/test_swift_stat.py
@@ -1,29 +1,41 @@
-import os
-import testinfra.utils.ansible_runner
-import pytest
-import pytest_rpc.helpers as helpers
-import utils as tmp_var
-
+# -*- coding: utf-8 -*-
 """ASC-299: Verify swift endpoint status
 
 See RPC 10+ Post-Deployment QC process document
 """
+# ==============================================================================
+# Imports
+# ==============================================================================
+import os
+import pytest
+import pytest_rpc.helpers as helpers
+import testinfra.utils.ansible_runner
 
+
+# ==============================================================================
+# Globals
+# ==============================================================================
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('shared-infra_hosts')[:1]
 
 
+# ==============================================================================
+# Test Cases
+# ==============================================================================
 @pytest.mark.test_id('d7fc4b42-432a-11e8-9ef9-6a00035510c0')
-@pytest.mark.jira('ASC-299', 'RI-519')
-def test_verify_swift_stat(host):
-    """Verify the swift endpoint status."""
+@pytest.mark.jira('ASC-299', 'RI-519', 'ASC-1327')
+def test_verify_swift_stat(host, openstack_properties):
+    """Verify the swift endpoint status.
 
-    r = next(tmp_var.gen_dict_extract('rpc_product_release',
-                                      host.ansible("setup")))
-    codename, major = helpers.get_osa_version(r)
+    Args:
+        host (testinfra.host.Host): Testinfra host fixture.
+        openstack_properties (dict): OpenStack facts and variables from Ansible
+            which can be used to manipulate OpenStack objects.
+    """
 
     cmd = 'swift stat -v'
-    if major < 17:
+
+    if openstack_properties['os_version_major'] < 17:
         result = helpers.run_on_swift(cmd, host)
     else:
         # Work around for ASC-1398:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 -c constraints.txt
 ansible
+configparser
 flake8-filename
 flake8-pytest-mark
 magic-marker

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,3 +19,4 @@
 - import_tasks: check_compute_service_status.yml
 - import_tasks: server_setup.yml
 - import_tasks: volume_setup.yml
+- import_tasks: os_version_file.yml

--- a/tasks/os_version_file.yml
+++ b/tasks/os_version_file.yml
@@ -1,0 +1,22 @@
+---
+# Task file for locating the 'clouds.yaml' file and placing it on the deployment host and infra1 host.
+
+
+- name: Extract '{{ os_version_file_path }}' Version File Contents from 'infra1' Host
+  slurp:
+    src: "{{ os_version_file_path }}"
+  register: os_version_file_contents
+
+
+- name: Create '{{ os_version_file_path }}' Version File on Deployment Host
+  copy:
+    content: "{{ os_version_file_contents.content | b64decode }}"
+    dest: "{{ os_version_file_path }}"
+  delegate_to: localhost
+
+- name: Modify '{{ os_version_file_path }}' Version File on Deployment Host with Default Section Header
+  lineinfile:
+    path: "{{ os_version_file_path }}"
+    line: "[default]"
+    insertbefore: BOF
+  delegate_to: localhost

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -34,6 +34,7 @@ test_subnet: TEST-VXLAN-SUBNET
 gateway_network: GATEWAY_NET
 private_network: PRIVATE_NET
 custom_fact_path: /etc/ansible/facts.d
+os_version_file_path: /etc/openstack-release
 
 # vars for copying 'clouds.yaml' to the deployment host
 os_config_path: /root/.config/openstack


### PR DESCRIPTION
Added a new Ansible task file for copying the OpenStack version file to the
deployment host and adding an INI section header. The version file is then
parsed by the 'openstack_properties' fixture for OpenStack version semantics.

Updated the test to utilize the fixture for discovering the version of
OpenStack along with styling and docstring updates.