### PR TITLE
ASC-1512 Use PRIVATE_NET for instance from vol

### DIFF
--- a/molecule/default/tests/test_create_instance_from_bootable_volume.py
+++ b/molecule/default/tests/test_create_instance_from_bootable_volume.py
@@ -7,7 +7,6 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('shared-infra_hosts')[:1]
 
 
-@pytest.mark.skip('ASC-1512', reason='test fails on OSP')
 @pytest.mark.test_id('8b701dbc-7584-11e8-ba5b-fe14fb7452aa')
 @pytest.mark.jira('asc-462')
 def test_create_instance_from_bootable_volume(openstack_properties,
@@ -22,7 +21,7 @@ def test_create_instance_from_bootable_volume(openstack_properties,
     """
 
     network_id = helpers.get_id_by_name('network',
-                                        openstack_properties['network_name'],
+                                        openstack_properties['private_net'],
                                         host)
     assert network_id is not None
 


### PR DESCRIPTION
This commit changes the network used for the instance created by
bootable volume.  Attempts to create such an instance using the
GATEWAY_NET as previously set consistently fail.  Using the PRIVATE_NET
successfully allows the instance to be created.  Since the network
binding is not significant to this test, it has no impact on the subject
under test.