### PR TITLE
ASC-1321 Refactor 'test_rpc_version'

### DIFF
--- a/molecule/default/tests/test_rpc_version.py
+++ b/molecule/default/tests/test_rpc_version.py
@@ -1,63 +1,105 @@
+# -*- coding: utf-8 -*-
+# ==============================================================================
+# Imports
+# ==============================================================================
 import os
-import testinfra.utils.ansible_runner
 import pytest
-import re
-import pytest_rpc.helpers as helpers
-import utils as tmp_var
+import testinfra.utils.ansible_runner
 
+
+# ==============================================================================
+# Globals
+# ==============================================================================
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('shared-infra_hosts')[:1]
 
 
-@pytest.mark.test_id('2c596d8f-7957-11e8-8017-6a00035510c0')
-@pytest.mark.jira('ASC-234')
-def test_openstack_release_version(host):
-    """Test to verify expected version of installed OpenStack
+# ==============================================================================
+# Helpers
+# ==============================================================================
+def gen_dict_extract(key, var):
+    """Produce a generator that can iterate over all found values for a given
+    key in a given dictionary
 
     Args:
-        host(testinfra.host.Host): host fixture that will iterate over
-            testinfra_hosts
+        key(str): key to lookup
+        var(dict): dictionary to recursively search
+
+    Returns: generator
     """
 
-    r = next(tmp_var.gen_dict_extract('rpc_product_release',
-                                      host.ansible("setup")))
-    expected_codename, expected_major = helpers.get_osa_version(r)
+    if hasattr(var, 'iteritems'):
+        for k, v in var.iteritems():
+            if k == key:
+                yield v
+            if isinstance(v, dict):
+                for result in gen_dict_extract(key, v):
+                    yield result
+            elif isinstance(v, list):
+                for d in v:
+                    for result in gen_dict_extract(key, d):
+                        yield result
 
-    # Expected example:
-    # DISTRIB_RELEASE="r16.2.0"
-    print "expected_major: {}".format(expected_major)
-    if expected_major.isdigit():
-        pat = expected_major + r'.\d+.\d+'
+
+def get_osa_version(branch):
+    """Get OpenStack version (code_name, major_version)
+
+    This data is based on the git branch of the test suite being executed
+
+    Args:
+        branch (str): The rpc-openstack branch to query for.
+
+    Returns:
+        tuple of (str, int): (code_name, major_version) OpenStack version. The
+            tuple will be (None, None) if the branch doesn't match known values.
+    """
+
+    if branch in ['newton', 'newton-rc']:
+        return 'Newton', 14
+    elif branch in ['pike', 'pike-rc']:
+        return 'Pike', 16
+    elif branch in ['queens', 'queens-rc']:
+        return 'Queens', 17
+    elif branch in ['rocky', 'rocky-rc']:
+        return 'Rocky', 18
     else:
-        pat = r'\w+'
-    expected_regex = re.compile('DISTRIB_RELEASE="r?{}"'.format(pat))
-    print "expected_regex: {}".format(expected_regex.pattern)
-    release = host.file('/etc/openstack-release').content
-    assert re.search(expected_regex, release)
+        return None, None
+
+
+# ==============================================================================
+# Test Cases
+# ==============================================================================
+@pytest.mark.test_id('2c596d8f-7957-11e8-8017-6a00035510c0')
+@pytest.mark.jira('ASC-234', 'ASC-1321')
+def test_openstack_release_version(host, openstack_properties):
+    """Verify the swift endpoint status.
+
+    Args:
+        host (testinfra.host.Host): Testinfra host fixture.
+        openstack_properties (dict): OpenStack facts and variables from Ansible
+            which can be used to manipulate OpenStack objects.
+    """
+
+    r = next(gen_dict_extract('rpc_product_release',
+                              host.ansible("setup")))
+    expected_codename, expected_major = get_osa_version(r)
+
+    assert openstack_properties['os_version_major'] == expected_major
 
 
 @pytest.mark.test_id('0d8e4105-789e-11e8-8335-6a00035510c0')
-@pytest.mark.jira('ASC-234')
-def test_openstack_codename(host):
-    """Test to verify expected codename of installed OpenStack
+@pytest.mark.jira('ASC-234', 'ASC-1321')
+def test_openstack_codename(host, openstack_properties):
+    """Verify the swift endpoint status.
 
     Args:
-        host(testinfra.host.Host): host fixture that will iterate over
-            testinfra_hosts
+        host (testinfra.host.Host): Testinfra host fixture.
+        openstack_properties (dict): OpenStack facts and variables from Ansible
+            which can be used to manipulate OpenStack objects.
     """
 
-    r = next(tmp_var.gen_dict_extract('rpc_product_release',
-                                      host.ansible("setup")))
-    expected_codename, expected_major = helpers.get_osa_version(r)
+    r = next(gen_dict_extract('rpc_product_release',
+                              host.ansible("setup")))
+    expected_codename, expected_major = get_osa_version(r)
 
-    # Expected example:
-    # DISTRIB_CODENAME="Pike"
-    print "expected_codename: {}".format(expected_codename)
-    if expected_codename:
-        pat = expected_codename
-    else:
-        pat = r'\w+'
-    expected_regex = re.compile('DISTRIB_CODENAME="{}"'.format(pat))
-    print "expected_regex: {}".format(expected_regex.pattern)
-    release = host.file('/etc/openstack-release').content
-    assert re.search(expected_regex, release)
+    assert openstack_properties['os_version_codename'] == expected_codename


### PR DESCRIPTION
Updated the test to utilize the updated 'openstack_properties' fixture which
includes OpenStack version information. Moved helpers from 'pytest-rpc' and
'utils.py' to this module given the narrow focus of said helpers. Updated
related tickets to indicate the change in location for the given helpers.