### PR TITLE
ASC-1543 Fix "configparser" Backport Issue

### DIFF
--- a/molecule/default/tests/conftest.py
+++ b/molecule/default/tests/conftest.py
@@ -13,7 +13,14 @@ from platform import system
 from subprocess import call
 from paramiko import SSHClient, AutoAddPolicy, HostKeys
 from paramiko.ssh_exception import NoValidConnectionsError
-from configparser import ConfigParser, NoOptionError, NoSectionError
+
+# Shakes tiny fist at Python 2.7!
+try:
+    # noinspection PyCompatibility
+    from ConfigParser import ConfigParser, NoOptionError, NoSectionError
+except ImportError:
+    # noinspection PyCompatibility
+    from configparser import ConfigParser, NoOptionError, NoSectionError
 
 
 # ==============================================================================


### PR DESCRIPTION
The "configparser" backport library isn't playing nice with Rocky Bionic.
Updated the import to attempt to load the old school "ConfigParser" built-in
first for Python 2.7 compatibility.