### PR TITLE
ASC-1559 Update "os_version_file" Task

### DIFF
--- a/tasks/os_version_file.yml
+++ b/tasks/os_version_file.yml
@@ -8,15 +8,15 @@
   register: os_version_file_contents
 
 
-- name: Create '{{ os_version_file_path }}' Version File on Deployment Host
+- name: Create '{{ os_version_ini_path }}' Version File on Deployment Host
   copy:
     content: "{{ os_version_file_contents.content | b64decode }}"
-    dest: "{{ os_version_file_path }}"
+    dest: "{{ os_version_ini_path }}"
   delegate_to: localhost
 
-- name: Modify '{{ os_version_file_path }}' Version File on Deployment Host with Default Section Header
+- name: Modify '{{ os_version_ini_path }}' Version File on Deployment Host with Default Section Header
   lineinfile:
-    path: "{{ os_version_file_path }}"
+    path: "{{ os_version_ini_path }}"
     line: "[default]"
     insertbefore: BOF
   delegate_to: localhost

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -35,6 +35,7 @@ gateway_network: GATEWAY_NET
 private_network: PRIVATE_NET
 custom_fact_path: /etc/ansible/facts.d
 os_version_file_path: /etc/openstack-release
+os_version_ini_path: /etc/openstack-release.ini
 
 # vars for copying 'clouds.yaml' to the deployment host
 os_config_path: /root/.config/openstack


### PR DESCRIPTION
Turns out that the CI scripts will lay down a copy of '/etc/openstack-release'
if it doesn't exist somewhere in the post process. However, it already exists
then it assumes that the file is readable. Adding the '[default]' INI section
to the file makes it fail to import which in turn causes the post script to
fail with the result of no qTest results being published.

So, the modified file is now being appended with the extension of '.ini' to
differentiate it from the original file.