### PR TITLE
ASC-1601 Fix "master" Branch Version Mismatch

### DIFF
--- a/molecule/default/tests/test_rpc_version.py
+++ b/molecule/default/tests/test_rpc_version.py
@@ -63,7 +63,7 @@ def get_osa_version(branch):
     elif branch in ['rocky', 'rocky-rc']:
         return 'Rocky', 18
     else:
-        return None, None
+        return 'master', 99
 
 
 # ==============================================================================


### PR DESCRIPTION
The "test_rpc_version" test module has a helper that did not properly identify
the "master" branch of RPC-O. I updated the helper to provide the fail safe
of codename "master" and version of "99" if the branch could not be determined.