### PR TITLE
ASC-1535 Standardize "testinfra" Hosts Group

### DIFF
--- a/molecule/default/tests/test_cinder_service.py
+++ b/molecule/default/tests/test_cinder_service.py
@@ -18,6 +18,8 @@ def test_cinder_service(os_api_conn, openstack_properties):
     Args:
         os_api_conn (openstack.connection.Connection): An authorized API
             connection to the 'default' cloud on the OpenStack infrastructure.
+        openstack_properties (dict): OpenStack facts and variables from Ansible
+            which can be used to manipulate OpenStack objects.
     """
     # Getting the right cinder service to check:
     #    Cinder API V1 was removed in Queens release (os_version_major == 17)

--- a/molecule/default/tests/test_list_cinder_volume_group_lxc.py
+++ b/molecule/default/tests/test_list_cinder_volume_group_lxc.py
@@ -8,6 +8,10 @@ import re
 import pytest
 import testinfra.utils.ansible_runner
 
+
+# ==============================================================================
+# Globals
+# ==============================================================================
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('cinder_volume')
 

--- a/molecule/default/tests/test_verify_galera_cluster.py
+++ b/molecule/default/tests/test_verify_galera_cluster.py
@@ -7,13 +7,14 @@ import os
 import pytest
 import testinfra.utils.ansible_runner
 
+
 # ==============================================================================
 # Globals
 # ==============================================================================
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('shared-infra_hosts')
 
-galera_container = ("lxc-attach -n $(lxc-ls -1 | grep galera | head -n 1) -- ")
+galera_container = "lxc-attach -n $(lxc-ls -1 | grep galera | head -n 1) -- "
 
 
 # ==============================================================================


### PR DESCRIPTION
Make sure that "shared-infra_hosts" is used as the hosts group when attempting
to access any of the "infra*" hosts.