### PR TITLE
ASC-1601 Conditionally Skip Version Check Test

### DIFF
--- a/molecule/default/tests/test_rpc_version.py
+++ b/molecule/default/tests/test_rpc_version.py
@@ -63,7 +63,7 @@ def get_osa_version(branch):
     elif branch in ['rocky', 'rocky-rc']:
         return 'Rocky', 18
     else:
-        return 'master', 99
+        return None, None
 
 
 # ==============================================================================
@@ -84,7 +84,7 @@ def test_openstack_release_version(host, openstack_properties):
                               host.ansible("setup")))
     expected_major = get_osa_version(r)[1]
 
-    if expected_major == 99:
+    if expected_major is None:
         pytest.skip('Test incompatible with RPC-O "master" branch.')
 
     assert openstack_properties['os_version_major'] == expected_major
@@ -105,7 +105,7 @@ def test_openstack_codename(host, openstack_properties):
                               host.ansible("setup")))
     expected_codename = get_osa_version(r)[0]
 
-    if expected_codename == 'master':
+    if expected_codename is None:
         pytest.skip('Test incompatible with RPC-O "master" branch.')
 
     assert openstack_properties['os_version_codename'] == expected_codename

--- a/molecule/default/tests/test_rpc_version.py
+++ b/molecule/default/tests/test_rpc_version.py
@@ -85,7 +85,7 @@ def test_openstack_release_version(host, openstack_properties):
     expected_major = get_osa_version(r)[1]
 
     if expected_major is None:
-        pytest.skip('Test incompatible with RPC-O "master" branch.')
+        pytest.skip('Expected release version is undefined for this branch.')
 
     assert openstack_properties['os_version_major'] == expected_major
 
@@ -106,6 +106,6 @@ def test_openstack_codename(host, openstack_properties):
     expected_codename = get_osa_version(r)[0]
 
     if expected_codename is None:
-        pytest.skip('Test incompatible with RPC-O "master" branch.')
+        pytest.skip('Expected release codename is undefined for this branch.')
 
     assert openstack_properties['os_version_codename'] == expected_codename

--- a/molecule/default/tests/test_rpc_version.py
+++ b/molecule/default/tests/test_rpc_version.py
@@ -70,7 +70,7 @@ def get_osa_version(branch):
 # Test Cases
 # ==============================================================================
 @pytest.mark.test_id('2c596d8f-7957-11e8-8017-6a00035510c0')
-@pytest.mark.jira('ASC-234', 'ASC-1321')
+@pytest.mark.jira('ASC-234', 'ASC-1321', 'ASC-1601')
 def test_openstack_release_version(host, openstack_properties):
     """Verify the swift endpoint status.
 
@@ -82,13 +82,16 @@ def test_openstack_release_version(host, openstack_properties):
 
     r = next(gen_dict_extract('rpc_product_release',
                               host.ansible("setup")))
-    expected_codename, expected_major = get_osa_version(r)
+    expected_major = get_osa_version(r)[1]
+
+    if expected_major == 99:
+        pytest.skip('Test incompatible with RPC-O "master" branch.')
 
     assert openstack_properties['os_version_major'] == expected_major
 
 
 @pytest.mark.test_id('0d8e4105-789e-11e8-8335-6a00035510c0')
-@pytest.mark.jira('ASC-234', 'ASC-1321')
+@pytest.mark.jira('ASC-234', 'ASC-1321', 'ASC-1602')
 def test_openstack_codename(host, openstack_properties):
     """Verify the swift endpoint status.
 
@@ -100,6 +103,9 @@ def test_openstack_codename(host, openstack_properties):
 
     r = next(gen_dict_extract('rpc_product_release',
                               host.ansible("setup")))
-    expected_codename, expected_major = get_osa_version(r)
+    expected_codename = get_osa_version(r)[0]
+
+    if expected_codename == 'master':
+        pytest.skip('Test incompatible with RPC-O "master" branch.')
 
     assert openstack_properties['os_version_codename'] == expected_codename


### PR DESCRIPTION
So it turns out that the '/etc/openstack-release' file on master branch does in
fact contain the correct codename! Given the weird nature of that file I think
it's best we just conditionally skip when on the 'master' branch.