### PR TITLE
ASC-1620 Fix Task Order

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,3 @@
+---
+# Include the Molecule requirements file.
+- include: molecule/default/requirements.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 # tasks file for molecule-rpc-openstack-post-deploy
-- import_tasks: server_delete.yml
 - import_role:
     name: ansible-role-pytest-rpc
+- import_tasks: server_delete.yml
 - import_tasks: apt_packages.yml
 - import_tasks: check_galera_status.yml
 - import_tasks: check_compute_service_status.yml


### PR DESCRIPTION
The "server_delete" task file should be after the role import for
"ansible-role-pytest-rpc" because the aforementioned task needs to have the
"clouds.yaml" file be moved to the deployment host before executing.