### PR TITLE
(ASC-1503) update test for validating volume snapshots

### DIFF
--- a/molecule/default/tests/test_cinder_lvm.py
+++ b/molecule/default/tests/test_cinder_lvm.py
@@ -7,6 +7,7 @@ RPC 10+ manual test 14.
 # ==============================================================================
 import os
 import pytest
+import pytest_rpc.helpers as helpers
 import testinfra.utils.ansible_runner
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
@@ -16,9 +17,12 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 # ==============================================================================
 # Test Cases
 # ==============================================================================
-@pytest.mark.jira('asc-157')
+@pytest.mark.jira('asc-157', 'asc-1503')
 @pytest.mark.test_id('b1e888fa-546a-11e8-9902-6c96cfdb252f')
-def test_cinder_lvs_volume_on_node(os_api_conn, host):
+def test_cinder_lvs_volume_on_node(os_api_conn,
+                                   create_volume,
+                                   openstack_properties,
+                                   host):
     """Test to verify that a volume associated to a cinder host can be seen
         on that cinder host as a logical volume. If there is any snapshot
         created from the volume, then the snapshot is only seen on the cinder
@@ -27,14 +31,28 @@ def test_cinder_lvs_volume_on_node(os_api_conn, host):
     Args:
         os_api_conn (openstack.connection.Connection): An authorized API
             connection to the 'default' cloud on the OpenStack infrastructure.
+        create_volume (def): A factory function for generating volumes.
+        openstack_properties (dict): OpenStack facts and variables from Ansible
         host (testinfra.host.Host): Testinfra host fixture.
     """
-    # get VolumeDetail
-    vol_details = os_api_conn.block_storage.volumes()
-    # get SnapshotDetails
-    snapshot_details = os_api_conn.block_storage.snapshots()
+    # create volume:
+    test_volume = create_volume(
+        size=1,
+        image=openstack_properties['cirros_image'],
+        bootable=False
+    )
 
-    for vol in vol_details:
+    # create a snapshot of the above newly created volume
+    vol_id = test_volume.id
+    snapshot_name = "test_volume_snapshot{}".format(
+        str(helpers.generate_random_string()))
+
+    test_snapshot = os_api_conn.create_volume_snapshot(volume_id=vol_id,
+                                                       name=snapshot_name,
+                                                       force=True,
+                                                       timeout=600)
+
+    for vol in os_api_conn.block_storage.volumes():
         chost = vol.to_dict()['host']
         chost = chost.split('@')[0].split('.')[0]
         vol_id = vol.to_dict()['id']
@@ -52,12 +70,20 @@ def test_cinder_lvs_volume_on_node(os_api_conn, host):
         # cinder volume
         if current_host == chost:
             cmd = "lvs |grep volume-{}".format(vol_id)
-            assert host.run(cmd), "The command: '{}' failed to run on host " \
-                                  "'{}'".format(cmd, current_host)
+            assert host.run(cmd).rc == 0,\
+                "The command: '{}' failed to run on " \
+                "host '{}'".format(cmd, current_host)
 
-            for snapshot in snapshot_details:
+            for snapshot in os_api_conn.block_storage.snapshots():
                 if snapshot.to_dict()['volume_id'] == vol_id:
                     snapshot_id = snapshot.to_dict()['id']
                     cmd = "lvs | grep _snapshot-{}".format(snapshot_id)
-                    assert host.run(cmd), "The command: '{}' failed to run on" \
-                                          "host '{}'.".format(cmd, current_host)
+                    assert host.run(cmd).rc == 0, \
+                        "The command: '{}' failed to run on" \
+                        "host '{}'.".format(cmd, current_host)
+
+    # tear down
+    # tear down snapshot only, the volume tear down is handled in create_volume
+    # factory function
+    snapshot_id = test_snapshot.id
+    os_api_conn.delete_volume_snapshot(name_or_id=snapshot_id, wait=True)


### PR DESCRIPTION
Prior to this PR, volumes are not created (due to the recent changes
in converge steps) and volume snapshot is not created for the test.

This PR adds volume and volume snapshot creation so that the test
can really test the cinder lvm volumes and volume snapshots.